### PR TITLE
remove /usr/include/filters from pkgconfig file as it is not installed

### DIFF
--- a/sensord-qt5.pc.in
+++ b/sensord-qt5.pc.in
@@ -7,4 +7,4 @@ Description: Sensord for Qt 5
 Version: 0.12.3
 Requires:
 Libs: -L${libdir} -lsensorclient-qt5 -lsensordatatypes-qt5
-Cflags: -I${includedir} -I${includedir}/datatypes -I${includedir}/filters
+Cflags: -I${includedir} -I${includedir}/datatypes


### PR DESCRIPTION
It seems /usr/include/filters is not being installed when running sequence:
```
qmake CONFIG+=mce PC_VERSION=0.12.3
make
make install
```
Afterwards, when installing qt5-sensors backend, the configure failures when checking directory and sensor-fw support is turned off. The failure of qt5-sensors could be seen with version 5.15.2 right after calling command
```
qmake CONFIG+=sensorfw
```
