### PR TITLE
Fix build on 32-bit kernels with 64-bit time_t

### DIFF
--- a/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
+++ b/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
@@ -102,7 +102,7 @@ void AccelerometerAdaptor::commitOutput(struct input_event *ev)
 {
     AccelerationData* d = accelerometerBuffer_->nextSlot();
 
-    d->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    d->timestamp_ = Utils::getTimeStamp(ev);
     d->x_ = orientationValue_.x_;
     d->y_ = orientationValue_.y_;
     d->z_ = orientationValue_.z_;

--- a/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
+++ b/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
@@ -79,7 +79,7 @@ void ALSAdaptorEvdev::commitOutput(struct input_event *ev)
     TimedUnsigned* lux = alsBuffer_->nextSlot();
     lux->value_ = alsValue_;
 
-    lux->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    lux->timestamp_ = Utils::getTimeStamp(ev);
 
     alsBuffer_->commit();
     alsBuffer_->wakeUpReaders();

--- a/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
+++ b/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
@@ -88,7 +88,7 @@ void GyroAdaptorEvdev::commitOutput(struct input_event *ev)
     gyroData->y_ = gyroValue_.y_;
     gyroData->z_ = gyroValue_.z_;
 
-    gyroData->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    gyroData->timestamp_ = Utils::getTimeStamp(ev);
 
     gyroscopeBuffer_->commit();
     gyroscopeBuffer_->wakeUpReaders();

--- a/adaptors/humidityadaptor/humidityadaptor.cpp
+++ b/adaptors/humidityadaptor/humidityadaptor.cpp
@@ -76,7 +76,7 @@ void HumidityAdaptor::commitOutput(struct input_event *ev)
     TimedUnsigned* rh = humidityBuffer_->nextSlot();
     rh->value_ = humidityValue_;
 
-    rh->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    rh->timestamp_ = Utils::getTimeStamp(ev);
 
     humidityBuffer_->commit();
     humidityBuffer_->wakeUpReaders();

--- a/adaptors/lidsensoradaptor-evdev/lidsensoradaptor-evdev.cpp
+++ b/adaptors/lidsensoradaptor-evdev/lidsensoradaptor-evdev.cpp
@@ -125,7 +125,7 @@ void LidSensorAdaptorEvdev::commitOutput(struct input_event *ev)
 
         LidData *lidData = lidBuffer_->nextSlot();
 
-        lidData->timestamp_ = Utils::getTimeStamp(&(ev->time));
+        lidData->timestamp_ = Utils::getTimeStamp(ev);
         lidData->value_ = currentValue_;
         lidData->type_ = currentType_;
         sensordLogD() << "Lid state change detected: "

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
@@ -87,7 +87,7 @@ void MagAdaptorEvdev::commitOutput(struct input_event *ev)
     magData->y_ = magValue_.y_;
     magData->z_ = magValue_.z_;
 
-    magData->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    magData->timestamp_ = Utils::getTimeStamp(ev);
 
     magnetometerBuffer_->commit();
     magnetometerBuffer_->wakeUpReaders();

--- a/adaptors/pressureadaptor/pressureadaptor.cpp
+++ b/adaptors/pressureadaptor/pressureadaptor.cpp
@@ -76,7 +76,7 @@ void PressureAdaptor::commitOutput(struct input_event *ev)
     TimedUnsigned* lux = pressureBuffer_->nextSlot();
     lux->value_ = pressureValue_;
 
-    lux->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    lux->timestamp_ = Utils::getTimeStamp(ev);
 
     pressureBuffer_->commit();
     pressureBuffer_->wakeUpReaders();

--- a/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.cpp
+++ b/adaptors/proximityadaptor-evdev/proximityadaptor-evdev.cpp
@@ -84,7 +84,7 @@ void ProximityAdaptorEvdev::commitOutput(struct input_event *ev)
 
         ProximityData *proximityData = proximityBuffer_->nextSlot();
 
-        proximityData->timestamp_ = Utils::getTimeStamp(&(ev->time));
+        proximityData->timestamp_ = Utils::getTimeStamp(ev);
         proximityData->withinProximity_ = currentState_;
 
         oldState = currentState_;

--- a/adaptors/tapadaptor/tapadaptor.cpp
+++ b/adaptors/tapadaptor/tapadaptor.cpp
@@ -69,7 +69,7 @@ void TapAdaptor::interpretEvent(int src, struct input_event *ev)
         }
         TapData tapValue;
         tapValue.direction_ = dir;
-        tapValue.timestamp_ = Utils::getTimeStamp(&(ev->time));
+        tapValue.timestamp_ = Utils::getTimeStamp(ev);
         tapValue.type_ = TapData::SingleTap;
 
         commitOutput(tapValue);

--- a/adaptors/temperatureadaptor/temperatureadaptor.cpp
+++ b/adaptors/temperatureadaptor/temperatureadaptor.cpp
@@ -76,7 +76,7 @@ void TemperatureAdaptor::commitOutput(struct input_event *ev)
     TimedUnsigned* temp = temperatureBuffer_->nextSlot();
     temp->value_ = temperatureValue_;
 
-    temp->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    temp->timestamp_ = Utils::getTimeStamp(ev);
 
     temperatureBuffer_->commit();
     temperatureBuffer_->wakeUpReaders();

--- a/adaptors/touchadaptor/touchadaptor.cpp
+++ b/adaptors/touchadaptor/touchadaptor.cpp
@@ -156,7 +156,7 @@ void TouchAdaptor::commitOutput(int src, struct input_event *ev)
 {
     TouchData* d = outputBuffer_->nextSlot();
 
-    d->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    d->timestamp_ = Utils::getTimeStamp(ev);
     d->x_ = touchValues_[src].x;
     d->y_ = touchValues_[src].y;
     d->z_ = touchValues_[src].z;

--- a/datatypes/utils.cpp
+++ b/datatypes/utils.cpp
@@ -71,10 +71,16 @@ quint64 Utils::getTimeStamp()
     return data;
 }
 
-quint64 Utils::getTimeStamp(const struct timeval *tp)
+quint64 Utils::getTimeStamp(const struct input_event *ie)
 {
-    quint64 data = tp->tv_sec;
+#ifdef input_event_sec
+    quint64 data = ie->input_event_sec;
     data = data * 1000000;
-    data = tp->tv_usec + data;
+    data = ie->input_event_usec + data;
+#else
+    quint64 data = ie->time.tv_sec;
+    data = data * 1000000;
+    data = ie->time.tv_usec + data;
+#endif
     return data;
 }

--- a/datatypes/utils.h
+++ b/datatypes/utils.h
@@ -27,7 +27,7 @@
 
 #ifndef UTILS_H
 #define UTILS_H
-#include <sys/time.h>
+#include <linux/input.h>
 
 /**
  * Collection of static utility functions.
@@ -47,7 +47,7 @@ public:
      *
      * @return timestamp.
      */
-    static quint64 getTimeStamp(const struct timeval*);
+    static quint64 getTimeStamp(const struct input_event*);
 };
 
 #endif // UTILS_H


### PR DESCRIPTION
This is the default on Musl libc since 1.2.0, and because of it sensorfw failed to build on 32-bit arches on Musl libc systems.

See https://musl.libc.org/time64.html for more details