### PR TITLE
pegatronaccelerometeradaptor: Fix build on 32-bit kernels with 64-bit…

### DIFF
--- a/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.cpp
+++ b/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.cpp
@@ -74,7 +74,7 @@ void PegatronAccelerometerAdaptor::commitOutput(struct input_event *ev)
 {
     OrientationData* d = accelerometerBuffer_->nextSlot();
 
-    d->timestamp_ = Utils::getTimeStamp(&(ev->time));
+    d->timestamp_ = Utils::getTimeStamp(ev);
     d->x_ = orientationValue_.x_;
     d->y_ = orientationValue_.y_;
     d->z_ = orientationValue_.z_;


### PR DESCRIPTION
… time_t

Other files were already fixed, but this one was missed in bc47e30bd843f9b99d8fe6f32b9ccf508ff03527

This is the default on Musl libc since 1.2.0, and because of it sensorfw failed to build on 32-bit arches on Musl libc systems.

See https://musl.libc.org/time64.html for more details

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>