### PR TITLE
[sendorfwd] Skip deadlocking libgbinder cleanup. Fixes JB#60298

### DIFF
--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -447,41 +447,44 @@ void HybrisManager::cleanup()
     if (m_pollTransactId) {
         gbinder_client_cancel(m_client, m_pollTransactId);
         m_pollTransactId = 0;
+
+        // The above code just marks down pending POLL transaction as
+        // to be cancelled later on when handler thread gets woken up.
+        //
+        // If we are exiting right after cleanup(), that is never going
+        // to happen and gbinder_ipc_exit() cleanup code blocks sensorfwd
+        // exit indefinitely.
+        //
+        // As a workaround: make a dummy POLL transaction, for which a
+        // reply is sent immediately, which then wakes up the handler
+        // thread, the cancellation gets processed and exit is unblocked.
+
+        GBinderLocalRequest *req = gbinder_client_new_request2(m_client, POLL);
+        int32_t status = 0;
+        gbinder_local_request_append_int32(req, 0);
+        GBinderRemoteReply *reply = gbinder_client_transact_sync_reply(m_client, POLL, req, &status);
+        gbinder_remote_reply_unref(reply);
+        gbinder_local_request_unref(req);
     }
 
-    if (m_sensorCallback) {
-        gbinder_local_object_unref(m_sensorCallback);
-        m_sensorCallback = NULL;
-    }
+    gbinder_local_object_unref(m_sensorCallback);
+    m_sensorCallback = NULL;
 
-    if (m_wakeLockQueue) {
-        gbinder_fmq_unref(m_wakeLockQueue);
-        m_wakeLockQueue = NULL;
-    }
+    gbinder_fmq_unref(m_wakeLockQueue);
+    m_wakeLockQueue = NULL;
 
-    if (m_eventQueue) {
-        gbinder_fmq_unref(m_eventQueue);
-        m_eventQueue = NULL;
-    }
+    gbinder_fmq_unref(m_eventQueue);
+    m_eventQueue = NULL;
 
-    if (m_client) {
-        gbinder_client_unref(m_client);
-        m_client = NULL;
-    }
+    gbinder_client_unref(m_client);
+    m_client = NULL;
 
-    if (m_remote) {
-        if (m_deathId) {
-            gbinder_remote_object_remove_handler(m_remote, m_deathId);
-            m_deathId = 0;
-        }
-        gbinder_remote_object_unref(m_remote);
-        m_remote = NULL;
-    }
+    gbinder_remote_object_remove_handler(m_remote, m_deathId);
+    m_deathId = 0;
 
-    if (m_serviceManager) {
-        gbinder_servicemanager_unref(m_serviceManager);
-        m_serviceManager = NULL;
-    }
+    gbinder_servicemanager_unref(m_serviceManager);
+    m_serviceManager = NULL;
+    m_remote = NULL; // auto-release
 
     for (int i = 0 ; i < m_sensorCount ; i++) {
         g_free((void*)m_sensorArray[i].name.data.str);
@@ -660,7 +663,6 @@ void HybrisManager::finishConnect()
 
     if (m_remote) {
         sensordLogD() << "Initialize sensor service";
-        gbinder_remote_object_ref(m_remote);
         m_deathId = gbinder_remote_object_add_death_handler(m_remote, binderDied, this);
         m_client = gbinder_client_new2(m_remote, sensors_2_client_ifaces, G_N_ELEMENTS(sensors_2_client_ifaces));
         if (!m_client) {
@@ -693,6 +695,7 @@ void HybrisManager::finishConnect()
 
             if (status != GBINDER_STATUS_OK) {
                 sensordLogW() << "Initialize failed with status" << status << ". Trying to reconnect.";
+                gbinder_remote_reply_unref(reply);
             } else {
                 int error;
                 GBinderReader reader;
@@ -716,7 +719,6 @@ void HybrisManager::finishConnect()
             sensordLogD() << "Could not find remote object for sensor service. Trying to reconnect";
         } else {
             m_sensorInterfaceEnum = SENSOR_INTERFACE_1_0;
-            gbinder_remote_object_ref(m_remote);
             sensordLogD() << "Connected to sensor 1.0 service";
             m_deathId = gbinder_remote_object_add_death_handler(m_remote, binderDied,
                             this);

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -1193,7 +1193,7 @@ void *HybrisManager::eventReaderThread(void *aptr)
         // Process received events
         int blockSuspend = 0;
         bool errorInInput = false;
-        manager->processEvents(buffer, numberOfEvents, blockSuspend, errorInInput);
+        manager->processEvents(buffer, eventsToRead, blockSuspend, errorInInput);
 
         // Suspend proof sensor reporting that could occur in display off
         if (blockSuspend) {


### PR DESCRIPTION
Stopping sensorfwd systemd service takes 15 seconds. This happens because libgbinder cleanup gets deadlocked by some kind of orphaned transaction of unknown origin that never finishes - which then requires systemd to go through TERM-wait-timeout-KILL cycle.

As the part of at-exit cleanup we really care about is getting sensor hw turned off: Refactor hybrisManager instance logic so that cleanup code that stops sensors gets executed along with exit from mainloop instead of after returning from main(). Then skip all further cleanup code that would be executed after return from main() by using _exit().