### PR TITLE
Always substract offset regardless of calLevel

### DIFF
--- a/chains/magcalibrationchain/calibrationfilter.cpp
+++ b/chains/magcalibrationchain/calibrationfilter.cpp
@@ -113,10 +113,6 @@ void CalibrationFilter::magDataAvailable(unsigned, const CalibratedMagneticField
 
             transformed.level_ = calLevel;
 
-            transformed.x_ -= offsetX;
-            transformed.y_ -= offsetY;
-            transformed.z_ -= offsetZ;
-
             ///////////////////// soft iron
             qreal vmaxX = minMaxList.at(0).second - ((minMaxList.at(0).first + minMaxList.at(0).second) * 0.5);
             qreal vmaxY = minMaxList.at(1).second - ((minMaxList.at(1).first + minMaxList.at(1).second) * 0.5);
@@ -141,6 +137,10 @@ void CalibrationFilter::magDataAvailable(unsigned, const CalibratedMagneticField
             zScale = (avgRad/avgZ);
         }
 
+        transformed.x_ -= offsetX;
+        transformed.y_ -= offsetY;
+        transformed.z_ -= offsetZ;
+       
         transformed.x_ *= xScale;
         transformed.y_ *= yScale;
         transformed.z_ *= zScale;


### PR DESCRIPTION
This patch fixes calibration of the magnetometer. Previously, the subtraction of the offset was being done only when `calLevel` was not `3`, or any of the offset components needed to be updated. However, even if calibration (i.e. the process of computing the right offsets) is finished, the subtraction must always be done as new raw data keeps going through the filter.

This has been tested a while back on the OG PinePhone running Ubuntu Touch 16.04 and it was proposed as part of a PR to the ubports fork of [sensorfw](https://gitlab.com/ubports/development/core/packaging/sensorfw/-/merge_requests/4). It was suggested there that this is instead sent upstream.