### PR TITLE
Data rate fixes

### DIFF
--- a/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
+++ b/adaptors/accelerometeradaptor/accelerometeradaptor.cpp
@@ -113,29 +113,6 @@ void AccelerometerAdaptor::commitOutput(struct input_event *ev)
     accelerometerBuffer_->wakeUpReaders();
 }
 
-unsigned int AccelerometerAdaptor::evaluateIntervalRequests(int& sessionId) const
-{
-    if (m_intervalMap.size() == 0) {
-        sessionId = -1;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it = m_intervalMap.constBegin();
-    unsigned int highestValue = it.value();
-    int winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it) {
-        if (((it.value() < highestValue) && (it.value() > 0)) || highestValue == 0) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 bool AccelerometerAdaptor::resume()
 {
    startSensor();

--- a/adaptors/accelerometeradaptor/accelerometeradaptor.h
+++ b/adaptors/accelerometeradaptor/accelerometeradaptor.h
@@ -70,11 +70,6 @@ protected:
     AccelerometerAdaptor(const QString& id);
     ~AccelerometerAdaptor();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<AccelerationData>* accelerometerBuffer_;
     AccelerationData orientationValue_;

--- a/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
+++ b/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
@@ -86,33 +86,6 @@ void ALSAdaptorEvdev::commitOutput(struct input_event *ev)
     alsBuffer_->wakeUpReaders();
 }
 
-unsigned int ALSAdaptorEvdev::evaluateIntervalRequests(int& sessionId) const
-{
-    unsigned int highestValue = 0;
-    int winningSessionId = -1;
-
-    if (m_intervalMap.size() == 0) {
-        sessionId = winningSessionId;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it;
-    it = m_intervalMap.begin();
-    highestValue = it.value();
-    winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it) {
-        if ((it.value() < highestValue) && (it.value() > 0)) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 bool ALSAdaptorEvdev::startSensor()
 {
     if (!powerStatePath_.isEmpty()) {

--- a/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
+++ b/adaptors/alsadaptor-evdev/alsevdevadaptor.cpp
@@ -45,7 +45,8 @@ ALSAdaptorEvdev::ALSAdaptorEvdev(const QString& id) :
     setDescription("Input device als adaptor");
     powerStatePath_ = SensorFrameworkConfig::configuration()->value("als/powerstate_path").toByteArray();
     introduceAvailableDataRange(DataRange(0, 4095, 1));
-    setDefaultInterval(10);
+    unsigned int interval_us = 10 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 ALSAdaptorEvdev::~ALSAdaptorEvdev()

--- a/adaptors/alsadaptor-evdev/alsevdevadaptor.h
+++ b/adaptors/alsadaptor-evdev/alsevdevadaptor.h
@@ -59,11 +59,6 @@ protected:
     ALSAdaptorEvdev(const QString& id);
     ~ALSAdaptorEvdev();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<TimedUnsigned>* alsBuffer_;
 

--- a/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
+++ b/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
@@ -95,33 +95,6 @@ void GyroAdaptorEvdev::commitOutput(struct input_event *ev)
     gyroscopeBuffer_->wakeUpReaders();
 }
 
-unsigned int GyroAdaptorEvdev::evaluateIntervalRequests(int& sessionId) const
-{
-    unsigned int highestValue = 0;
-    int winningSessionId = -1;
-
-    if (m_intervalMap.size() == 0) {
-        sessionId = winningSessionId;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it;
-    it = m_intervalMap.begin();
-    highestValue = it.value();
-    winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it) {
-        if ((it.value() < highestValue) && (it.value() > 0)) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 bool GyroAdaptorEvdev::startSensor()
 {
     if (!powerStatePath_.isEmpty()) {

--- a/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
+++ b/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.cpp
@@ -45,7 +45,8 @@ GyroAdaptorEvdev::GyroAdaptorEvdev(const QString& id) :
     setDescription("Input device gyroscope adaptor");
     powerStatePath_ = SensorFrameworkConfig::configuration()->value("gyroscope/powerstate_path").toByteArray();
    // introduceAvailableDataRange(DataRange(0, 4095, 1));
-    setDefaultInterval(10);
+    unsigned int interval_us = 10 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 GyroAdaptorEvdev::~GyroAdaptorEvdev()

--- a/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.h
+++ b/adaptors/gyroscopeadaptor-evdev/gyroevdevadaptor.h
@@ -59,11 +59,6 @@ protected:
     GyroAdaptorEvdev(const QString& id);
     ~GyroAdaptorEvdev();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<TimedXyzData>* gyroscopeBuffer_;
 

--- a/adaptors/gyroscopeadaptor/gyroscopeadaptor.cpp
+++ b/adaptors/gyroscopeadaptor/gyroscopeadaptor.cpp
@@ -70,10 +70,10 @@ void GyroscopeAdaptor::processSample(int pathId, int fd)
     gyroscopeBuffer_->wakeUpReaders();
 }
 
-bool GyroscopeAdaptor::setInterval(const unsigned int value, const int sessionId)
+bool GyroscopeAdaptor::setInterval(const int sessionId, const unsigned int value)
 {
     if (mode() == SysfsAdaptor::IntervalMode)
-        return SysfsAdaptor::setInterval(value, sessionId);
+        return SysfsAdaptor::setInterval(sessionId, value);
 
     int rate = value==0?100:1000/value;
     sensordLogD() << "Setting poll interval for " << dataRatePath_ << " to " << rate;

--- a/adaptors/gyroscopeadaptor/gyroscopeadaptor.cpp
+++ b/adaptors/gyroscopeadaptor/gyroscopeadaptor.cpp
@@ -70,14 +70,18 @@ void GyroscopeAdaptor::processSample(int pathId, int fd)
     gyroscopeBuffer_->wakeUpReaders();
 }
 
-bool GyroscopeAdaptor::setInterval(const int sessionId, const unsigned int value)
+bool GyroscopeAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
 {
     if (mode() == SysfsAdaptor::IntervalMode)
-        return SysfsAdaptor::setInterval(sessionId, value);
+        return SysfsAdaptor::setInterval(sessionId, interval_ms);
 
-    int rate = value==0?100:1000/value;
-    sensordLogD() << "Setting poll interval for " << dataRatePath_ << " to " << rate;
-    QByteArray dataRateString(QString("%1\n").arg(rate).toLocal8Bit());
+    int rate_Hz = 0;
+    if (interval_ms > 0)
+        rate_Hz = 1000 / interval_ms;
+    if (rate_Hz <= 0)
+        rate_Hz = 100;
+    sensordLogD() << "Setting poll interval for " << dataRatePath_ << " to " << rate_Hz;
+    QByteArray dataRateString(QString("%1\n").arg(rate_Hz).toLocal8Bit());
     return writeToFile(dataRatePath_, dataRateString);
 }
 
@@ -86,5 +90,7 @@ unsigned int GyroscopeAdaptor::interval() const
     if (mode() == SysfsAdaptor::IntervalMode)
         return SysfsAdaptor::interval();
     QByteArray byteArray = readFromFile(dataRatePath_);
-    return byteArray.size() > 0 ? byteArray.toInt() : 0;
+    int rate_Hz = byteArray.size() > 0 ? byteArray.toInt() : 0;
+    int interval_ms = rate_Hz > 0 ? 1000 / rate_Hz : 0;
+    return interval_ms;
 }

--- a/adaptors/gyroscopeadaptor/gyroscopeadaptor.cpp
+++ b/adaptors/gyroscopeadaptor/gyroscopeadaptor.cpp
@@ -70,14 +70,14 @@ void GyroscopeAdaptor::processSample(int pathId, int fd)
     gyroscopeBuffer_->wakeUpReaders();
 }
 
-bool GyroscopeAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
+bool GyroscopeAdaptor::setInterval(const int sessionId, const unsigned int interval_us)
 {
     if (mode() == SysfsAdaptor::IntervalMode)
-        return SysfsAdaptor::setInterval(sessionId, interval_ms);
+        return SysfsAdaptor::setInterval(sessionId, interval_us);
 
     int rate_Hz = 0;
-    if (interval_ms > 0)
-        rate_Hz = 1000 / interval_ms;
+    if (interval_us > 0)
+        rate_Hz = 1000000 / interval_us;
     if (rate_Hz <= 0)
         rate_Hz = 100;
     sensordLogD() << "Setting poll interval for " << dataRatePath_ << " to " << rate_Hz;
@@ -91,6 +91,6 @@ unsigned int GyroscopeAdaptor::interval() const
         return SysfsAdaptor::interval();
     QByteArray byteArray = readFromFile(dataRatePath_);
     int rate_Hz = byteArray.size() > 0 ? byteArray.toInt() : 0;
-    int interval_ms = rate_Hz > 0 ? 1000 / rate_Hz : 0;
-    return interval_ms;
+    int interval_us = rate_Hz > 0 ? 1000000 / rate_Hz : 0;
+    return interval_us;
 }

--- a/adaptors/gyroscopeadaptor/gyroscopeadaptor.h
+++ b/adaptors/gyroscopeadaptor/gyroscopeadaptor.h
@@ -69,7 +69,7 @@ protected:
      */
     ~GyroscopeAdaptor();
 
-    bool setInterval(const int sessionId, const unsigned int interval_ms);
+    bool setInterval(const int sessionId, const unsigned int interval_us);
     unsigned int interval() const;
 
 private:

--- a/adaptors/gyroscopeadaptor/gyroscopeadaptor.h
+++ b/adaptors/gyroscopeadaptor/gyroscopeadaptor.h
@@ -69,7 +69,7 @@ protected:
      */
     ~GyroscopeAdaptor();
 
-    bool setInterval(const int sessionId, const unsigned int value);
+    bool setInterval(const int sessionId, const unsigned int interval_ms);
     unsigned int interval() const;
 
 private:

--- a/adaptors/gyroscopeadaptor/gyroscopeadaptor.h
+++ b/adaptors/gyroscopeadaptor/gyroscopeadaptor.h
@@ -69,7 +69,7 @@ protected:
      */
     ~GyroscopeAdaptor();
 
-    bool setInterval(const unsigned int value, const int sessionId);
+    bool setInterval(const int sessionId, const unsigned int value);
     unsigned int interval() const;
 
 private:

--- a/adaptors/humidityadaptor/humidityadaptor.cpp
+++ b/adaptors/humidityadaptor/humidityadaptor.cpp
@@ -42,7 +42,8 @@ HumidityAdaptor::HumidityAdaptor(const QString& id) :
     setDescription("Input device humidity adaptor");
     powerStatePath_ = SensorFrameworkConfig::configuration()->value("humidity/powerstate_path").toByteArray();
     introduceAvailableDataRange(DataRange(0, 4095, 1));
-    setDefaultInterval(10);
+    unsigned int interval_us = 10 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 HumidityAdaptor::~HumidityAdaptor()

--- a/adaptors/humidityadaptor/humidityadaptor.cpp
+++ b/adaptors/humidityadaptor/humidityadaptor.cpp
@@ -83,33 +83,6 @@ void HumidityAdaptor::commitOutput(struct input_event *ev)
     humidityBuffer_->wakeUpReaders();
 }
 
-unsigned int HumidityAdaptor::evaluateIntervalRequests(int& sessionId) const
-{
-    unsigned int highestValue = 0;
-    int winningSessionId = -1;
-
-    if (m_intervalMap.size() == 0) {
-        sessionId = winningSessionId;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it;
-    it = m_intervalMap.begin();
-    highestValue = it.value();
-    winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it) {
-        if ((it.value() < highestValue) && (it.value() > 0)) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 bool HumidityAdaptor::startSensor()
 {
     if (!powerStatePath_.isEmpty()) {

--- a/adaptors/humidityadaptor/humidityadaptor.h
+++ b/adaptors/humidityadaptor/humidityadaptor.h
@@ -59,11 +59,6 @@ protected:
     HumidityAdaptor(const QString& id);
     ~HumidityAdaptor();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<TimedUnsigned>* humidityBuffer_;
 

--- a/adaptors/hybrisaccelerometer/hybrisaccelerometeradaptor.cpp
+++ b/adaptors/hybrisaccelerometer/hybrisaccelerometeradaptor.cpp
@@ -30,7 +30,8 @@ HybrisAccelerometerAdaptor::HybrisAccelerometerAdaptor(const QString& id) :
 
     setDescription("Hybris accelerometer");
     powerStatePath = SensorFrameworkConfig::configuration()->value("accelerometer/powerstate_path").toByteArray();
-//    setDefaultInterval(50);
+//    unsigned int interval_us = 50 * 1000;
+//    setDefaultInterval(interval_us);
 }
 
 HybrisAccelerometerAdaptor::~HybrisAccelerometerAdaptor()

--- a/adaptors/hybrisgyroscopeadaptor/hybrisgyroscopeadaptor.cpp
+++ b/adaptors/hybrisgyroscopeadaptor/hybrisgyroscopeadaptor.cpp
@@ -36,7 +36,8 @@ HybrisGyroscopeAdaptor::HybrisGyroscopeAdaptor(const QString& id) :
     	sensordLogW() << "Path does not exists: " << powerStatePath;
     	powerStatePath.clear();
     }
-    setDefaultInterval(50);
+    unsigned int interval_us = 50 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 HybrisGyroscopeAdaptor::~HybrisGyroscopeAdaptor()

--- a/adaptors/hybrismagnetometeradaptor/hybrismagnetometeradaptor.cpp
+++ b/adaptors/hybrismagnetometeradaptor/hybrismagnetometeradaptor.cpp
@@ -36,7 +36,8 @@ HybrisMagnetometerAdaptor::HybrisMagnetometerAdaptor(const QString& id) :
     	powerStatePath.clear();
     }
     //setStandbyOverride(false);
-    setDefaultInterval(50);
+    unsigned int interval_us = 50 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 HybrisMagnetometerAdaptor::~HybrisMagnetometerAdaptor()

--- a/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.cpp
+++ b/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.cpp
@@ -52,7 +52,8 @@ HybrisOrientationAdaptor::HybrisOrientationAdaptor(const QString& id) :
     	sensordLogW() << "Path does not exists: " << powerStatePath;
     	powerStatePath.clear();
     }
-//    setDefaultInterval(50);
+//    unsigned int interval_us = 50 * 1000;
+//    setDefaultInterval(interval_us);
 }
 
 HybrisOrientationAdaptor::~HybrisOrientationAdaptor()

--- a/adaptors/iioadaptor/iioadaptor.cpp
+++ b/adaptors/iioadaptor/iioadaptor.cpp
@@ -548,21 +548,21 @@ void IioAdaptor::processSample(int fileId, int fd)
     }
 }
 
-bool IioAdaptor::setInterval(const int sessionId, const unsigned int value)
+bool IioAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
 {
     if (mode() == SysfsAdaptor::IntervalMode)
-        return SysfsAdaptor::setInterval(sessionId, value);
+        return SysfsAdaptor::setInterval(sessionId, interval_ms);
 
-    sensordLogD() << "Ignoring setInterval for " << value;
+    sensordLogD() << "Ignoring setInterval for " << interval_ms;
 
     return true;
 }
 
 //unsigned int IioAdaptor::interval() const
 //{
-//    int value = 100;
-//    sensordLogD() << "Returning dummy value in interval(): " << value;
-//    return value;
+//    int interval_ms = 100;
+//    sensordLogD() << "Returning dummy value in interval(): " << interval_ms;
+//    return interval_ms;
 //}
 
 

--- a/adaptors/iioadaptor/iioadaptor.cpp
+++ b/adaptors/iioadaptor/iioadaptor.cpp
@@ -548,10 +548,10 @@ void IioAdaptor::processSample(int fileId, int fd)
     }
 }
 
-bool IioAdaptor::setInterval(const unsigned int value, const int sessionId)
+bool IioAdaptor::setInterval(const int sessionId, const unsigned int value)
 {
     if (mode() == SysfsAdaptor::IntervalMode)
-        return SysfsAdaptor::setInterval(value, sessionId);
+        return SysfsAdaptor::setInterval(sessionId, value);
 
     sensordLogD() << "Ignoring setInterval for " << value;
 

--- a/adaptors/iioadaptor/iioadaptor.cpp
+++ b/adaptors/iioadaptor/iioadaptor.cpp
@@ -180,8 +180,13 @@ void IioAdaptor::setup()
     }
 
     introduceAvailableDataRange(DataRange(0, 65535, 1));
-    introduceAvailableInterval(DataRange(0, 586, 0));
-    setDefaultInterval(10);
+
+    unsigned int min_interval_us =   0 * 1000;
+    unsigned int max_interval_us = 586 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+
+    unsigned int interval_us = 10 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 int IioAdaptor::findSensor(const QString &sensorName)
@@ -548,21 +553,21 @@ void IioAdaptor::processSample(int fileId, int fd)
     }
 }
 
-bool IioAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
+bool IioAdaptor::setInterval(const int sessionId, const unsigned int interval_us)
 {
     if (mode() == SysfsAdaptor::IntervalMode)
-        return SysfsAdaptor::setInterval(sessionId, interval_ms);
+        return SysfsAdaptor::setInterval(sessionId, interval_us);
 
-    sensordLogD() << "Ignoring setInterval for " << interval_ms;
+    sensordLogD() << "Ignoring setInterval for " << interval_us;
 
     return true;
 }
 
 //unsigned int IioAdaptor::interval() const
 //{
-//    int interval_ms = 100;
-//    sensordLogD() << "Returning dummy value in interval(): " << interval_ms;
-//    return interval_ms;
+//    int interval_us = 100 * 1000;
+//    sensordLogD() << "Returning dummy value in interval(): " << interval_us;
+//    return interval_us;
 //}
 
 

--- a/adaptors/iioadaptor/iioadaptor.h
+++ b/adaptors/iioadaptor/iioadaptor.h
@@ -104,7 +104,7 @@ protected:
     ~IioAdaptor();
 
 
-    bool setInterval(const int sessionId, const unsigned int value);
+    bool setInterval(const int sessionId, const unsigned int interval_ms);
     //  unsigned int interval() const;
 
 private:

--- a/adaptors/iioadaptor/iioadaptor.h
+++ b/adaptors/iioadaptor/iioadaptor.h
@@ -104,7 +104,7 @@ protected:
     ~IioAdaptor();
 
 
-    bool setInterval(const unsigned int value, const int sessionId);
+    bool setInterval(const int sessionId, const unsigned int value);
     //  unsigned int interval() const;
 
 private:

--- a/adaptors/iioadaptor/iioadaptor.h
+++ b/adaptors/iioadaptor/iioadaptor.h
@@ -104,7 +104,7 @@ protected:
     ~IioAdaptor();
 
 
-    bool setInterval(const int sessionId, const unsigned int interval_ms);
+    bool setInterval(const int sessionId, const unsigned int interval_us);
     //  unsigned int interval() const;
 
 private:

--- a/adaptors/kbslideradaptor/kbslideradaptor.cpp
+++ b/adaptors/kbslideradaptor/kbslideradaptor.cpp
@@ -103,7 +103,7 @@ unsigned int KeyboardSliderAdaptor::interval() const
     return 0;
 }
 
-bool KeyboardSliderAdaptor::setInterval(unsigned int value, int sessionId)
+bool KeyboardSliderAdaptor::setInterval(int sessionId, unsigned int value)
 {
     Q_UNUSED(value);
     Q_UNUSED(sessionId);

--- a/adaptors/kbslideradaptor/kbslideradaptor.cpp
+++ b/adaptors/kbslideradaptor/kbslideradaptor.cpp
@@ -103,9 +103,9 @@ unsigned int KeyboardSliderAdaptor::interval() const
     return 0;
 }
 
-bool KeyboardSliderAdaptor::setInterval(int sessionId, unsigned int interval_ms)
+bool KeyboardSliderAdaptor::setInterval(int sessionId, unsigned int interval_us)
 {
-    Q_UNUSED(interval_ms);
+    Q_UNUSED(interval_us);
     Q_UNUSED(sessionId);
     return true;
 }

--- a/adaptors/kbslideradaptor/kbslideradaptor.cpp
+++ b/adaptors/kbslideradaptor/kbslideradaptor.cpp
@@ -103,9 +103,9 @@ unsigned int KeyboardSliderAdaptor::interval() const
     return 0;
 }
 
-bool KeyboardSliderAdaptor::setInterval(int sessionId, unsigned int value)
+bool KeyboardSliderAdaptor::setInterval(int sessionId, unsigned int interval_ms)
 {
-    Q_UNUSED(value);
+    Q_UNUSED(interval_ms);
     Q_UNUSED(sessionId);
     return true;
 }

--- a/adaptors/kbslideradaptor/kbslideradaptor.h
+++ b/adaptors/kbslideradaptor/kbslideradaptor.h
@@ -66,7 +66,7 @@ protected:
     ~KeyboardSliderAdaptor();
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(unsigned int value, int sessionId);
+    virtual bool setInterval(int sessionId, unsigned int value);
 
 private:
 

--- a/adaptors/kbslideradaptor/kbslideradaptor.h
+++ b/adaptors/kbslideradaptor/kbslideradaptor.h
@@ -66,7 +66,7 @@ protected:
     ~KeyboardSliderAdaptor();
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(int sessionId, unsigned int interval_ms);
+    virtual bool setInterval(int sessionId, unsigned int interval_us);
 
 private:
 

--- a/adaptors/kbslideradaptor/kbslideradaptor.h
+++ b/adaptors/kbslideradaptor/kbslideradaptor.h
@@ -66,7 +66,7 @@ protected:
     ~KeyboardSliderAdaptor();
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(int sessionId, unsigned int value);
+    virtual bool setInterval(int sessionId, unsigned int interval_ms);
 
 private:
 

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
@@ -44,7 +44,8 @@ MagAdaptorEvdev::MagAdaptorEvdev(const QString& id) :
     setDescription("Input device magnetometer adaptor");
     powerStatePath_ = SensorFrameworkConfig::configuration()->value("magnetometer/powerstate_path").toByteArray();
   //  introduceAvailableDataRange(DataRange(0, 4095, 1));
-    setDefaultInterval(10);
+    unsigned int interval_us = 10 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 MagAdaptorEvdev::~MagAdaptorEvdev()

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.cpp
@@ -94,33 +94,6 @@ void MagAdaptorEvdev::commitOutput(struct input_event *ev)
     magnetometerBuffer_->wakeUpReaders();
 }
 
-unsigned int MagAdaptorEvdev::evaluateIntervalRequests(int& sessionId) const
-{
-    unsigned int highestValue = 0;
-    int winningSessionId = -1;
-
-    if (m_intervalMap.size() == 0) {
-        sessionId = winningSessionId;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it;
-    it = m_intervalMap.begin();
-    highestValue = it.value();
-    winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it) {
-        if ((it.value() < highestValue) && (it.value() > 0)) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 bool MagAdaptorEvdev::startSensor()
 {
     if (!powerStatePath_.isEmpty()) {

--- a/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.h
+++ b/adaptors/magnetometeradaptor-evdev/magnetometerevdevadaptor.h
@@ -62,11 +62,6 @@ protected:
     MagAdaptorEvdev(const QString& id);
     ~MagAdaptorEvdev();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetometerBuffer_;
 

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
@@ -151,13 +151,13 @@ void MagnetometerAdaptorNCDK::stopSensor()
     SysfsAdaptor::stopSensor();
 }
 
-bool MagnetometerAdaptorNCDK::setInterval(const int sessionId, const unsigned int value)
+bool MagnetometerAdaptorNCDK::setInterval(const int sessionId, const unsigned int interval_ms)
 {
     if(intervalCompensation_)
     {
-        return SysfsAdaptor::setInterval(sessionId, (int)value > intervalCompensation_ ? value - intervalCompensation_ : 0);
+        return SysfsAdaptor::setInterval(sessionId, (int)interval_ms > intervalCompensation_ ? interval_ms - intervalCompensation_ : 0);
     }
-    return SysfsAdaptor::setInterval(sessionId, value);
+    return SysfsAdaptor::setInterval(sessionId, interval_ms);
 }
 
 void MagnetometerAdaptorNCDK::setOverflowLimit(int limit)

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
@@ -32,31 +32,32 @@
 
 MagnetometerAdaptorNCDK::MagnetometerAdaptorNCDK(const QString& id) :
     SysfsAdaptor(id, SysfsAdaptor::IntervalMode),
-    powerState_(false)
+    m_powerState(false)
 {
-    intervalCompensation_ = SensorFrameworkConfig::configuration()->value<int>("magnetometer/interval_compensation", 0);
-    powerStateFilePath_ = SensorFrameworkConfig::configuration()->value<QByteArray>("magnetometer/path_power_state", "");
-    sensAdjFilePath_ = SensorFrameworkConfig::configuration()->value<QByteArray>("magnetometer/path_sens_adjust", "");
-    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(128);
-    setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", magnetometerBuffer_);
+    int intervalCompensation_ms = SensorFrameworkConfig::configuration()->value<int>("magnetometer/interval_compensation", 0);
+    m_intervalCompensation_us = intervalCompensation_ms * 1000;
+    m_powerStateFilePath = SensorFrameworkConfig::configuration()->value<QByteArray>("magnetometer/path_power_state", "");
+    m_sensAdjFilePath = SensorFrameworkConfig::configuration()->value<QByteArray>("magnetometer/path_sens_adjust", "");
+    m_magnetometerBuffer = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(128);
+    setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", m_magnetometerBuffer);
     setDescription("Magnetometer adaptor (ak8975) for NCDK");
 
     //get sensitivity adjustment
-    getSensitivityAdjustment(x_adj, y_adj, z_adj);
+    getSensitivityAdjustment(m_x_adj, m_y_adj, m_z_adj);
 
-    overflowLimit_ = SensorFrameworkConfig::configuration()->value<int>("magnetometer/overflow_limit", 8000);
+    m_overflowLimit = SensorFrameworkConfig::configuration()->value<int>("magnetometer/overflow_limit", 8000);
 }
 
 MagnetometerAdaptorNCDK::~MagnetometerAdaptorNCDK()
 {
-    delete magnetometerBuffer_;
+    delete m_magnetometerBuffer;
 }
 
 void MagnetometerAdaptorNCDK::processSample(int pathId, int fd)
 {
     Q_UNUSED(pathId);
 
-    if (!powerState_)
+    if (!m_powerState)
         return;
 
     char buf[32];
@@ -69,9 +70,9 @@ void MagnetometerAdaptorNCDK::processSample(int pathId, int fd)
     if (isOK) {
         strList = QByteArray(buf, bytesRead).split(':');
         if (strList.size() == 3) {
-            x = adjustPos(strList.at(0).toInt(), x_adj);
-            y = adjustPos(strList.at(1).toInt(), y_adj);
-            z = adjustPos(strList.at(2).toInt(), z_adj);
+            x = adjustPos(strList.at(0).toInt(), m_x_adj);
+            y = adjustPos(strList.at(1).toInt(), m_y_adj);
+            z = adjustPos(strList.at(2).toInt(), m_z_adj);
         }
     } else {
         sensordLogW() << "Reading magnetometer error: " << strerror(errno);
@@ -80,15 +81,15 @@ void MagnetometerAdaptorNCDK::processSample(int pathId, int fd)
 
     sensordLogT() << "Magnetometer Reading: " << x << ", " << y << ", " << z;
 
-    CalibratedMagneticFieldData* sample = magnetometerBuffer_->nextSlot();
+    CalibratedMagneticFieldData *sample = m_magnetometerBuffer->nextSlot();
 
     sample->timestamp_ = Utils::getTimeStamp();
     sample->x_ = x;
     sample->y_ = y;
     sample->z_ = z;
 
-    magnetometerBuffer_->commit();
-    magnetometerBuffer_->wakeUpReaders();
+    m_magnetometerBuffer->commit();
+    m_magnetometerBuffer->wakeUpReaders();
 }
 
 bool MagnetometerAdaptorNCDK::setPowerState(bool value) const
@@ -97,7 +98,7 @@ bool MagnetometerAdaptorNCDK::setPowerState(bool value) const
 
     QByteArray powerStateStr = QByteArray::number(value);
 
-    if (!writeToFile(powerStateFilePath_, powerStateStr))
+    if (!writeToFile(m_powerStateFilePath, powerStateStr))
     {
         sensordLogW() << "Unable to set power state for compass driver";
         return false;
@@ -107,7 +108,7 @@ bool MagnetometerAdaptorNCDK::setPowerState(bool value) const
 
 void MagnetometerAdaptorNCDK::getSensitivityAdjustment(int &x, int &y, int &z) const
 {
-    QByteArray byteArray = readFromFile(sensAdjFilePath_);
+    QByteArray byteArray = readFromFile(m_sensAdjFilePath);
 
     QList<QByteArray> strList = byteArray.split(':');
     if (strList.size() == 3)
@@ -131,7 +132,7 @@ bool MagnetometerAdaptorNCDK::startSensor()
     }
     else
     {
-        powerState_ = true;
+        m_powerState = true;
     }
 
     return SysfsAdaptor::startSensor();
@@ -145,27 +146,27 @@ void MagnetometerAdaptorNCDK::stopSensor()
     }
     else
     {
-        powerState_ = false;
+        m_powerState = false;
     }
 
     SysfsAdaptor::stopSensor();
 }
 
-bool MagnetometerAdaptorNCDK::setInterval(const int sessionId, const unsigned int interval_ms)
+bool MagnetometerAdaptorNCDK::setInterval(const int sessionId, const unsigned int interval_us)
 {
-    if(intervalCompensation_)
+    if(m_intervalCompensation_us)
     {
-        return SysfsAdaptor::setInterval(sessionId, (int)interval_ms > intervalCompensation_ ? interval_ms - intervalCompensation_ : 0);
+        return SysfsAdaptor::setInterval(sessionId, (int)interval_us > m_intervalCompensation_us ? interval_us - m_intervalCompensation_us : 0);
     }
-    return SysfsAdaptor::setInterval(sessionId, interval_ms);
+    return SysfsAdaptor::setInterval(sessionId, interval_us);
 }
 
 void MagnetometerAdaptorNCDK::setOverflowLimit(int limit)
 {
-    overflowLimit_ = limit;
+    m_overflowLimit = limit;
 }
 
 int MagnetometerAdaptorNCDK::overflowLimit() const
 {
-    return overflowLimit_;
+    return m_overflowLimit;
 }

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.cpp
@@ -151,13 +151,13 @@ void MagnetometerAdaptorNCDK::stopSensor()
     SysfsAdaptor::stopSensor();
 }
 
-bool MagnetometerAdaptorNCDK::setInterval(const unsigned int value, const int sessionId)
+bool MagnetometerAdaptorNCDK::setInterval(const int sessionId, const unsigned int value)
 {
     if(intervalCompensation_)
     {
-        return SysfsAdaptor::setInterval((int)value > intervalCompensation_ ? value - intervalCompensation_ : 0, sessionId);
+        return SysfsAdaptor::setInterval(sessionId, (int)value > intervalCompensation_ ? value - intervalCompensation_ : 0);
     }
-    return SysfsAdaptor::setInterval(value, sessionId);
+    return SysfsAdaptor::setInterval(sessionId, value);
 }
 
 void MagnetometerAdaptorNCDK::setOverflowLimit(int limit)

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
@@ -58,7 +58,7 @@ protected:
     MagnetometerAdaptorNCDK(const QString& id);
     ~MagnetometerAdaptorNCDK();
 
-    bool setInterval(const int sessionId, const unsigned int value);
+    bool setInterval(const int sessionId, const unsigned int interval_ms);
 
 private:
 

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
@@ -58,7 +58,7 @@ protected:
     MagnetometerAdaptorNCDK(const QString& id);
     ~MagnetometerAdaptorNCDK();
 
-    bool setInterval(const int sessionId, const unsigned int interval_ms);
+    bool setInterval(const int sessionId, const unsigned int interval_us);
 
 private:
 
@@ -71,18 +71,22 @@ private:
      */
     void processSample(int pathId, int fd);
 
-    QByteArray powerStateFilePath_;
-    QByteArray sensAdjFilePath_;
+    QByteArray m_powerStateFilePath;
+    QByteArray m_sensAdjFilePath;
 
-    int x_adj, y_adj, z_adj;
-    bool powerState_;
-    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetometerBuffer_;
+    int m_x_adj;
+    int m_y_adj;
+    int m_z_adj;
+    bool m_powerState;
+
+    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData> *m_magnetometerBuffer;
 
     bool setPowerState(bool value) const;
     void getSensitivityAdjustment(int &x, int &y, int &z) const;
+
     int adjustPos(const int value, const int adj) const;
-    int intervalCompensation_;
-    int overflowLimit_;
+    int m_intervalCompensation_us;
+    int m_overflowLimit;
 
     /**
      * Sets the overflow limit of the sensor, checked when calibrated

--- a/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
+++ b/adaptors/magnetometeradaptor-ncdk/magnetometeradaptor-ncdk.h
@@ -58,7 +58,7 @@ protected:
     MagnetometerAdaptorNCDK(const QString& id);
     ~MagnetometerAdaptorNCDK();
 
-    bool setInterval(const unsigned int value, const int sessionId);
+    bool setInterval(const int sessionId, const unsigned int value);
 
 private:
 

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
@@ -89,13 +89,13 @@ void MagnetometerAdaptor::processSample(int pathId, int fd)
     magnetometerBuffer_->wakeUpReaders();
 }
 
-bool MagnetometerAdaptor::setInterval(const int sessionId, const unsigned int value)
+bool MagnetometerAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
 {
     if(intervalCompensation_)
     {
-        return SysfsAdaptor::setInterval(sessionId, (signed)value >intervalCompensation_ ? value - intervalCompensation_ : 0);
+        return SysfsAdaptor::setInterval(sessionId, (signed)interval_ms >intervalCompensation_ ? interval_ms - intervalCompensation_ : 0);
     }
-    return SysfsAdaptor::setInterval(sessionId, value);
+    return SysfsAdaptor::setInterval(sessionId, interval_ms);
 }
 
 void MagnetometerAdaptor::setOverflowLimit(int limit)

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
@@ -89,13 +89,13 @@ void MagnetometerAdaptor::processSample(int pathId, int fd)
     magnetometerBuffer_->wakeUpReaders();
 }
 
-bool MagnetometerAdaptor::setInterval(const unsigned int value, const int sessionId)
+bool MagnetometerAdaptor::setInterval(const int sessionId, const unsigned int value)
 {
     if(intervalCompensation_)
     {
-        return SysfsAdaptor::setInterval((signed)value >intervalCompensation_ ? value - intervalCompensation_ : 0, sessionId);
+        return SysfsAdaptor::setInterval(sessionId, (signed)value >intervalCompensation_ ? value - intervalCompensation_ : 0);
     }
-    return SysfsAdaptor::setInterval(value, sessionId);
+    return SysfsAdaptor::setInterval(sessionId, value);
 }
 
 void MagnetometerAdaptor::setOverflowLimit(int limit)

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.cpp
@@ -46,16 +46,17 @@ struct ak8974_data {
 MagnetometerAdaptor::MagnetometerAdaptor(const QString& id) :
     SysfsAdaptor(id, SysfsAdaptor::IntervalMode, false)
 {
-    intervalCompensation_ = SensorFrameworkConfig::configuration()->value<int>("magnetometer/interval_compensation", 0);
-    magnetometerBuffer_ = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(1);
-    setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", magnetometerBuffer_);
-    overflowLimit_ = SensorFrameworkConfig::configuration()->value<int>("magnetometer/overflow_limit", 8000);
+    int intervalCompensation_ms = SensorFrameworkConfig::configuration()->value<int>("magnetometer/interval_compensation", 0);
+    m_intervalCompensation_us = intervalCompensation_ms * 1000;
+    m_magnetometerBuffer = new DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>(1);
+    setAdaptedSensor("magnetometer", "Internal magnetometer coordinates", m_magnetometerBuffer);
+    m_overflowLimit = SensorFrameworkConfig::configuration()->value<int>("magnetometer/overflow_limit", 8000);
     setDescription("Input device Magnetometer adaptor (ak897x)");
 }
 
 MagnetometerAdaptor::~MagnetometerAdaptor()
 {
-    delete magnetometerBuffer_;
+    delete m_magnetometerBuffer;
 }
 
 void MagnetometerAdaptor::processSample(int pathId, int fd)
@@ -78,32 +79,32 @@ void MagnetometerAdaptor::processSample(int pathId, int fd)
 
     sensordLogT() << "Magnetometer reading: " << mag_data.x << ", " << mag_data.y << ", " << mag_data.z;
 
-    CalibratedMagneticFieldData* sample = magnetometerBuffer_->nextSlot();
+    CalibratedMagneticFieldData *sample = m_magnetometerBuffer->nextSlot();
 
     sample->timestamp_ = Utils::getTimeStamp();
     sample->x_ = mag_data.x;
     sample->y_ = mag_data.y;
     sample->z_ = mag_data.z;
 
-    magnetometerBuffer_->commit();
-    magnetometerBuffer_->wakeUpReaders();
+    m_magnetometerBuffer->commit();
+    m_magnetometerBuffer->wakeUpReaders();
 }
 
-bool MagnetometerAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
+bool MagnetometerAdaptor::setInterval(const int sessionId, const unsigned int interval_us)
 {
-    if(intervalCompensation_)
+    if(m_intervalCompensation_us)
     {
-        return SysfsAdaptor::setInterval(sessionId, (signed)interval_ms >intervalCompensation_ ? interval_ms - intervalCompensation_ : 0);
+        return SysfsAdaptor::setInterval(sessionId, (signed)interval_us >m_intervalCompensation_us ? interval_us - m_intervalCompensation_us : 0);
     }
-    return SysfsAdaptor::setInterval(sessionId, interval_ms);
+    return SysfsAdaptor::setInterval(sessionId, interval_us);
 }
 
 void MagnetometerAdaptor::setOverflowLimit(int limit)
 {
-    overflowLimit_ = limit;
+    m_overflowLimit = limit;
 }
 
 int MagnetometerAdaptor::overflowLimit() const
 {
-    return overflowLimit_;
+    return m_overflowLimit;
 }

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.h
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.h
@@ -64,7 +64,7 @@ protected:
     MagnetometerAdaptor(const QString& id);
     ~MagnetometerAdaptor();
 
-    bool setInterval(const int sessionId, const unsigned int value);
+    bool setInterval(const int sessionId, const unsigned int interval_ms);
 
 private:
 

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.h
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.h
@@ -64,7 +64,7 @@ protected:
     MagnetometerAdaptor(const QString& id);
     ~MagnetometerAdaptor();
 
-    bool setInterval(const int sessionId, const unsigned int interval_ms);
+    bool setInterval(const int sessionId, const unsigned int interval_us);
 
 private:
 
@@ -91,9 +91,9 @@ private:
      */
     int overflowLimit() const;
 
-    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetometerBuffer_;
-    int intervalCompensation_;
-    int overflowLimit_;
+    DeviceAdaptorRingBuffer<CalibratedMagneticFieldData> *m_magnetometerBuffer;
+    int m_intervalCompensation_us;
+    int m_overflowLimit;
 };
 
 #endif

--- a/adaptors/magnetometeradaptor/magnetometeradaptor.h
+++ b/adaptors/magnetometeradaptor/magnetometeradaptor.h
@@ -64,7 +64,7 @@ protected:
     MagnetometerAdaptor(const QString& id);
     ~MagnetometerAdaptor();
 
-    bool setInterval(const unsigned int value, const int sessionId);
+    bool setInterval(const int sessionId, const unsigned int value);
 
 private:
 

--- a/adaptors/mpu6050accelerometer/mpu6050accelerometeradaptor.cpp
+++ b/adaptors/mpu6050accelerometer/mpu6050accelerometeradaptor.cpp
@@ -66,8 +66,11 @@ Mpu6050AccelAdaptor::Mpu6050AccelAdaptor (const QString& id) :
 
     setDescription("MPU 6050 accelerometer");
 //    introduceAvailableDataRange(DataRange(-16384, 16384, 1));
-//    introduceAvailableInterval(DataRange(10, 586, 0));
-//    setDefaultInterval(100);
+//    unsigned int min_interval_us =  10 * 1000;
+//    unsigned int max_interval_us = 586 * 1000;
+//    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+//    unsigned int interval_us = 100 * 1000;
+//    setDefaultInterval(interval_us);
 }
 
 Mpu6050AccelAdaptor::~Mpu6050AccelAdaptor () {

--- a/adaptors/oaktrailaccelerometer/oaktrailaccelerometeradaptor.cpp
+++ b/adaptors/oaktrailaccelerometer/oaktrailaccelerometeradaptor.cpp
@@ -26,8 +26,13 @@ OaktrailAccelAdaptor::OaktrailAccelAdaptor (const QString& id) :
 
     setDescription("Oaktrail accelerometer");
     introduceAvailableDataRange(DataRange(-256, 256, 1));
-    introduceAvailableInterval(DataRange(10, 586, 0));
-    setDefaultInterval(100);
+
+    unsigned int min_interval_us =  10 * 1000;
+    unsigned int max_interval_us = 586 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+
+    unsigned int interval_us = 100 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 OaktrailAccelAdaptor::~OaktrailAccelAdaptor () {

--- a/adaptors/oemtabletaccelerometer/oemtabletaccelerometeradaptor.cpp
+++ b/adaptors/oemtabletaccelerometer/oemtabletaccelerometeradaptor.cpp
@@ -26,8 +26,13 @@ OemtabletAccelAdaptor::OemtabletAccelAdaptor (const QString& id) :
 
     setDescription("OEM tablet accelerometer");
     introduceAvailableDataRange(DataRange(-256, 256, 1));
-    introduceAvailableInterval(DataRange(10, 586, 0));
-    setDefaultInterval(0);
+
+    unsigned int min_interval_us =  10 * 1000;
+    unsigned int max_interval_us = 586 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+
+    // FIXME: what meaning zero default interval is supposed to have here?
+    // setDefaultInterval(0);
 }
 
 OemtabletAccelAdaptor::~OemtabletAccelAdaptor () {

--- a/adaptors/oemtabletalsadaptor-ascii/oemtabletalsadaptor-ascii.cpp
+++ b/adaptors/oemtabletalsadaptor-ascii/oemtabletalsadaptor-ascii.cpp
@@ -42,8 +42,13 @@ OEMTabletALSAdaptorAscii::OEMTabletALSAdaptorAscii(const QString& id) : SysfsAda
 
     setDescription("Ambient light");
     introduceAvailableDataRange(DataRange(0, range, 1));
-    introduceAvailableInterval(DataRange(10, 98, 0));
-    setDefaultInterval(90);
+
+    unsigned int min_interval_us = 10 * 1000;
+    unsigned int max_interval_us = 98 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+
+    unsigned int interval_us = 90 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 OEMTabletALSAdaptorAscii::~OEMTabletALSAdaptorAscii()

--- a/adaptors/oemtabletgyroscopeadaptor/oemtabletgyroscopeadaptor.cpp
+++ b/adaptors/oemtabletgyroscopeadaptor/oemtabletgyroscopeadaptor.cpp
@@ -14,8 +14,13 @@ OEMTabletGyroscopeAdaptor::OEMTabletGyroscopeAdaptor(const QString& id) :
     setAdaptedSensor("gyroscope", "mpu3050", gyroscopeBuffer_);
 
     introduceAvailableDataRange(DataRange(-32768, 32767, 1));
-    introduceAvailableInterval(DataRange(10, 113, 0));
-    setDefaultInterval(100);
+
+    unsigned int min_interval_us =  10 * 1000;
+    unsigned int max_interval_us = 113 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+
+    unsigned int interval_us = 100 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 OEMTabletGyroscopeAdaptor::~OEMTabletGyroscopeAdaptor()

--- a/adaptors/oemtabletmagnetometeradaptor/oemtabletmagnetometeradaptor.cpp
+++ b/adaptors/oemtabletmagnetometeradaptor/oemtabletmagnetometeradaptor.cpp
@@ -20,8 +20,13 @@ OemtabletMagnetometerAdaptor::OemtabletMagnetometerAdaptor(const QString& id) :
 
     setDescription("OEM tablet magnetometer");
     introduceAvailableDataRange(DataRange(-2048, 2048, 1));
-    introduceAvailableInterval(DataRange(10, 556, 0));
-    setDefaultInterval(500);
+
+    unsigned int min_interval_us =  10 * 1000;
+    unsigned int max_interval_us = 556 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+
+    unsigned int interval_us = 500 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 OemtabletMagnetometerAdaptor::~OemtabletMagnetometerAdaptor()

--- a/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.cpp
+++ b/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.cpp
@@ -88,32 +88,3 @@ void PegatronAccelerometerAdaptor::commitOutput(struct input_event *ev)
     accelerometerBuffer_->commit();
     accelerometerBuffer_->wakeUpReaders();
 }
-
-unsigned int PegatronAccelerometerAdaptor::evaluateIntervalRequests(int& sessionId) const
-{
-    unsigned int highestValue = 0;
-    int winningSessionId = -1;
-
-    if (m_intervalMap.size() == 0)
-    {
-        sessionId = winningSessionId;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it;
-    it = m_intervalMap.begin();
-    highestValue = it.value();
-    winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it)
-    {
-        if ((it.value() < highestValue) && (it.value() > 0)) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}

--- a/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.cpp
+++ b/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.cpp
@@ -32,9 +32,15 @@ PegatronAccelerometerAdaptor::PegatronAccelerometerAdaptor(const QString& id) :
     // Set Metadata
     setDescription("Input device accelerometer adaptor (Pegtron Lucid Tablet)");
     introduceAvailableDataRange(DataRange(-512, 512, 1));
+
     introduceAvailableInterval(DataRange(0, 0, 0));
-    introduceAvailableInterval(DataRange(50, 2000, 0)); // -> [1,100] Hz
-    setDefaultInterval(300);
+
+    unsigned int min_interval_us =   50 * 1000;
+    unsigned int max_interval_us = 2000 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
+
+    unsigned int interval_us = 300 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 PegatronAccelerometerAdaptor::~PegatronAccelerometerAdaptor()

--- a/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.h
+++ b/adaptors/pegatronaccelerometeradaptor/pegatronaccelerometeradaptor.h
@@ -27,11 +27,6 @@ protected:
     PegatronAccelerometerAdaptor(const QString& id);
     ~PegatronAccelerometerAdaptor();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<OrientationData>* accelerometerBuffer_;
     OrientationData orientationValue_;

--- a/adaptors/pressureadaptor/pressureadaptor.cpp
+++ b/adaptors/pressureadaptor/pressureadaptor.cpp
@@ -83,33 +83,6 @@ void PressureAdaptor::commitOutput(struct input_event *ev)
     pressureBuffer_->wakeUpReaders();
 }
 
-unsigned int PressureAdaptor::evaluateIntervalRequests(int& sessionId) const
-{
-    unsigned int highestValue = 0;
-    int winningSessionId = -1;
-
-    if (m_intervalMap.size() == 0) {
-        sessionId = winningSessionId;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it;
-    it = m_intervalMap.begin();
-    highestValue = it.value();
-    winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it) {
-        if ((it.value() < highestValue) && (it.value() > 0)) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 bool PressureAdaptor::startSensor()
 {
     if (!powerStatePath_.isEmpty()) {

--- a/adaptors/pressureadaptor/pressureadaptor.cpp
+++ b/adaptors/pressureadaptor/pressureadaptor.cpp
@@ -42,7 +42,8 @@ PressureAdaptor::PressureAdaptor(const QString& id) :
     setDescription("Input device pressure adaptor");
     powerStatePath_ = SensorFrameworkConfig::configuration()->value("pressure/powerstate_path").toByteArray();
     introduceAvailableDataRange(DataRange(0, 4095, 1));
-    setDefaultInterval(10);
+    unsigned int interval_us = 10 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 PressureAdaptor::~PressureAdaptor()

--- a/adaptors/pressureadaptor/pressureadaptor.h
+++ b/adaptors/pressureadaptor/pressureadaptor.h
@@ -59,11 +59,6 @@ protected:
     PressureAdaptor(const QString& id);
     ~PressureAdaptor();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<TimedUnsigned>* pressureBuffer_;
 

--- a/adaptors/steaccelerometeradaptor/steaccelerometeradaptor.cpp
+++ b/adaptors/steaccelerometeradaptor/steaccelerometeradaptor.cpp
@@ -18,8 +18,10 @@ SteAccelAdaptor::SteAccelAdaptor(const QString& id) :
 {
     buffer = new DeviceAdaptorRingBuffer<OrientationData>(128);
     setAdaptedSensor("accelerometer", "ste accelerometer", buffer);
-    introduceAvailableInterval(DataRange(50, 1000, 0));
 
+    unsigned int min_interval_us =   50 * 1000;
+    unsigned int max_interval_us = 1000 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
 /*
 range
 0: +/- 2g (1 mg/LSB)

--- a/adaptors/tapadaptor/tapadaptor.cpp
+++ b/adaptors/tapadaptor/tapadaptor.cpp
@@ -94,7 +94,7 @@ void TapAdaptor::commitOutput(const TapData& data)
     tapBuffer_->wakeUpReaders();
 }
 
-bool TapAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
+bool TapAdaptor::setInterval(const int sessionId, const unsigned int interval_us)
 {
     return true;
 }

--- a/adaptors/tapadaptor/tapadaptor.cpp
+++ b/adaptors/tapadaptor/tapadaptor.cpp
@@ -94,7 +94,7 @@ void TapAdaptor::commitOutput(const TapData& data)
     tapBuffer_->wakeUpReaders();
 }
 
-bool TapAdaptor::setInterval(const unsigned int, const int)
+bool TapAdaptor::setInterval(const int sessionId, const unsigned int value)
 {
     return true;
 }

--- a/adaptors/tapadaptor/tapadaptor.cpp
+++ b/adaptors/tapadaptor/tapadaptor.cpp
@@ -94,7 +94,7 @@ void TapAdaptor::commitOutput(const TapData& data)
     tapBuffer_->wakeUpReaders();
 }
 
-bool TapAdaptor::setInterval(const int sessionId, const unsigned int value)
+bool TapAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
 {
     return true;
 }

--- a/adaptors/tapadaptor/tapadaptor.h
+++ b/adaptors/tapadaptor/tapadaptor.h
@@ -59,7 +59,7 @@ protected:
     TapAdaptor(const QString& id);
     ~TapAdaptor();
 
-    virtual bool setInterval(const int sessionId, const unsigned int value);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
 
 private:
     DeviceAdaptorRingBuffer<TapData>* tapBuffer_; /**< Output buffer */

--- a/adaptors/tapadaptor/tapadaptor.h
+++ b/adaptors/tapadaptor/tapadaptor.h
@@ -59,7 +59,7 @@ protected:
     TapAdaptor(const QString& id);
     ~TapAdaptor();
 
-    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_us);
 
 private:
     DeviceAdaptorRingBuffer<TapData>* tapBuffer_; /**< Output buffer */

--- a/adaptors/tapadaptor/tapadaptor.h
+++ b/adaptors/tapadaptor/tapadaptor.h
@@ -59,7 +59,7 @@ protected:
     TapAdaptor(const QString& id);
     ~TapAdaptor();
 
-    virtual bool setInterval(const unsigned int value, const int sessionId);
+    virtual bool setInterval(const int sessionId, const unsigned int value);
 
 private:
     DeviceAdaptorRingBuffer<TapData>* tapBuffer_; /**< Output buffer */

--- a/adaptors/temperatureadaptor/temperatureadaptor.cpp
+++ b/adaptors/temperatureadaptor/temperatureadaptor.cpp
@@ -83,33 +83,6 @@ void TemperatureAdaptor::commitOutput(struct input_event *ev)
     temperatureBuffer_->wakeUpReaders();
 }
 
-unsigned int TemperatureAdaptor::evaluateIntervalRequests(int& sessionId) const
-{
-    unsigned int highestValue = 0;
-    int winningSessionId = -1;
-
-    if (m_intervalMap.size() == 0) {
-        sessionId = winningSessionId;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it;
-    it = m_intervalMap.begin();
-    highestValue = it.value();
-    winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it) {
-        if ((it.value() < highestValue) && (it.value() > 0)) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 bool TemperatureAdaptor::startSensor()
 {
     if (!powerStatePath_.isEmpty()) {

--- a/adaptors/temperatureadaptor/temperatureadaptor.cpp
+++ b/adaptors/temperatureadaptor/temperatureadaptor.cpp
@@ -42,7 +42,8 @@ TemperatureAdaptor::TemperatureAdaptor(const QString& id) :
     setDescription("Input device temperature adaptor");
     powerStatePath_ = SensorFrameworkConfig::configuration()->value("temperature/powerstate_path").toByteArray();
     introduceAvailableDataRange(DataRange(0, 4095, 1));
-    setDefaultInterval(10);
+    unsigned int interval_us = 10 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 TemperatureAdaptor::~TemperatureAdaptor()

--- a/adaptors/temperatureadaptor/temperatureadaptor.h
+++ b/adaptors/temperatureadaptor/temperatureadaptor.h
@@ -58,11 +58,6 @@ protected:
     TemperatureAdaptor(const QString& id);
     ~TemperatureAdaptor();
 
-    /**
-     * Reimplement to allow for 0 interval to be the slowest entry.
-     */
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
-
 private:
     DeviceAdaptorRingBuffer<TimedUnsigned>* temperatureBuffer_;
 

--- a/chains/compasschain/compasschain.cpp
+++ b/chains/compasschain/compasschain.cpp
@@ -161,7 +161,10 @@ CompassChain::CompassChain(const QString& id) :
 
     setDescription("Compass direction"); //compass north in degrees
     introduceAvailableDataRange(DataRange(0, 359, 1));
-    introduceAvailableInterval(DataRange(50,200,0));
+
+    unsigned int min_interval_us =  50 * 1000;
+    unsigned int max_interval_us = 200 * 1000;
+    introduceAvailableInterval(DataRange(min_interval_us, max_interval_us, 0));
 
     if (!hasOrientationAdaptor) {
         DownsampleFilter *filter = static_cast<DownsampleFilter *>(downsampleFilter);

--- a/core/abstractsensor_a.cpp
+++ b/core/abstractsensor_a.cpp
@@ -105,6 +105,14 @@ void AbstractSensorChannelAdaptor::setInterval(int sessionId, int interval_ms)
     SensorManager::instance().socketHandler().setInterval(sessionId, interval_ms);
 }
 
+void AbstractSensorChannelAdaptor::setDataRate(int sessionId, double dataRate_Hz)
+{
+    // interval_ms rounded down -> effective dataRate rounded up
+    int interval_ms = (dataRate_Hz > 0) ? (int)(1000.0 / dataRate_Hz) : 0;
+    node()->setIntervalRequest(sessionId, interval_ms);
+    SensorManager::instance().socketHandler().setInterval(sessionId, interval_ms);
+}
+
 bool AbstractSensorChannelAdaptor::standbyOverride() const
 {
     return node()->standbyOverride();

--- a/core/abstractsensor_a.cpp
+++ b/core/abstractsensor_a.cpp
@@ -99,10 +99,10 @@ void AbstractSensorChannelAdaptor::stop(int sessionId)
     node()->stop(sessionId);
 }
 
-void AbstractSensorChannelAdaptor::setInterval(int sessionId, int value)
+void AbstractSensorChannelAdaptor::setInterval(int sessionId, int interval_ms)
 {
-    node()->setIntervalRequest(sessionId, value);
-    SensorManager::instance().socketHandler().setInterval(sessionId, value);
+    node()->setIntervalRequest(sessionId, interval_ms);
+    SensorManager::instance().socketHandler().setInterval(sessionId, interval_ms);
 }
 
 bool AbstractSensorChannelAdaptor::standbyOverride() const
@@ -147,22 +147,22 @@ bool AbstractSensorChannelAdaptor::setDefaultInterval(int sessionId)
     return ok;
 }
 
-void AbstractSensorChannelAdaptor::setBufferInterval(int sessionId, unsigned int value)
+void AbstractSensorChannelAdaptor::setBufferInterval(int sessionId, unsigned int interval_ms)
 {
     bool hwBuffering = false;
     node()->getAvailableBufferIntervals(hwBuffering);
     if(hwBuffering)
     {
-        if(value == 0)
+        if(interval_ms == 0)
             node()->clearBufferInterval(sessionId);
         else
-            node()->setBufferInterval(sessionId, value);
-        value = 0;
+            node()->setBufferInterval(sessionId, interval_ms);
+        interval_ms = 0;
     }
-    if(value == 0)
+    if(interval_ms == 0)
         SensorManager::instance().socketHandler().clearBufferInterval(sessionId);
     else
-        SensorManager::instance().socketHandler().setBufferInterval(sessionId, value);
+        SensorManager::instance().socketHandler().setBufferInterval(sessionId, interval_ms);
 }
 
 void AbstractSensorChannelAdaptor::setBufferSize(int sessionId, unsigned int value)

--- a/core/abstractsensor_a.cpp
+++ b/core/abstractsensor_a.cpp
@@ -64,12 +64,22 @@ QString AbstractSensorChannelAdaptor::id() const
 
 unsigned int AbstractSensorChannelAdaptor::interval() const
 {
-    return node()->getInterval();
+    // D-Bus interface -> interval is milliseconds
+    int interval_ms = 0;
+    int interval_us = node()->getInterval();
+    if (interval_us > 0)
+        interval_ms = (interval_us + 999) / 1000;
+    return interval_ms;
 }
 
 unsigned int AbstractSensorChannelAdaptor::bufferInterval() const
 {
-    return node()->bufferInterval();
+    // D-Bus interface -> interval is milliseconds
+    int interval_ms = 0;
+    int interval_us = node()->bufferInterval();
+    if (interval_us > 0)
+        interval_ms = (interval_us + 999) / 1000;
+    return interval_ms;
 }
 
 unsigned int AbstractSensorChannelAdaptor::bufferSize() const
@@ -101,16 +111,22 @@ void AbstractSensorChannelAdaptor::stop(int sessionId)
 
 void AbstractSensorChannelAdaptor::setInterval(int sessionId, int interval_ms)
 {
-    node()->setIntervalRequest(sessionId, interval_ms);
-    SensorManager::instance().socketHandler().setInterval(sessionId, interval_ms);
+    // D-Bus interface -> interval is milliseconds
+    int interval_us = 0;
+    if (interval_ms > 0)
+        interval_us = interval_ms * 1000;
+    node()->setIntervalRequest(sessionId, interval_us);
+    SensorManager::instance().socketHandler().setInterval(sessionId, interval_us);
 }
 
 void AbstractSensorChannelAdaptor::setDataRate(int sessionId, double dataRate_Hz)
 {
-    // interval_ms rounded down -> effective dataRate rounded up
-    int interval_ms = (dataRate_Hz > 0) ? (int)(1000.0 / dataRate_Hz) : 0;
-    node()->setIntervalRequest(sessionId, interval_ms);
-    SensorManager::instance().socketHandler().setInterval(sessionId, interval_ms);
+    // interval_us rounded down -> effective dataRate rounded up
+    int interval_us = 0;
+    if (dataRate_Hz > 0)
+        interval_us = (int)(1000000.0 / dataRate_Hz);
+    node()->setIntervalRequest(sessionId, interval_us);
+    SensorManager::instance().socketHandler().setInterval(sessionId, interval_us);
 }
 
 bool AbstractSensorChannelAdaptor::standbyOverride() const
@@ -157,20 +173,24 @@ bool AbstractSensorChannelAdaptor::setDefaultInterval(int sessionId)
 
 void AbstractSensorChannelAdaptor::setBufferInterval(int sessionId, unsigned int interval_ms)
 {
+    // D-Bus interface -> interval is milliseconds
+    int interval_us = 0;
+    if (interval_ms > 0)
+        interval_us = interval_ms * 1000;
     bool hwBuffering = false;
     node()->getAvailableBufferIntervals(hwBuffering);
     if(hwBuffering)
     {
-        if(interval_ms == 0)
+        if(interval_us == 0)
             node()->clearBufferInterval(sessionId);
         else
-            node()->setBufferInterval(sessionId, interval_ms);
-        interval_ms = 0;
+            node()->setBufferInterval(sessionId, interval_us);
+        interval_us = 0;
     }
-    if(interval_ms == 0)
+    if(interval_us == 0)
         SensorManager::instance().socketHandler().clearBufferInterval(sessionId);
     else
-        SensorManager::instance().socketHandler().setBufferInterval(sessionId, interval_ms);
+        SensorManager::instance().socketHandler().setBufferInterval(sessionId, interval_us);
 }
 
 void AbstractSensorChannelAdaptor::setBufferSize(int sessionId, unsigned int value)
@@ -192,8 +212,14 @@ void AbstractSensorChannelAdaptor::setBufferSize(int sessionId, unsigned int val
 
 IntegerRangeList AbstractSensorChannelAdaptor::getAvailableBufferIntervals() const
 {
+    // D-Bus interface -> interval is milliseconds
     bool dummy;
-    return node()->getAvailableBufferIntervals(dummy);
+    IntegerRangeList list(node()->getAvailableBufferIntervals(dummy));
+    for (auto it = list.begin(); it != list.end(); ++it) {
+        (*it).first = ((*it).first + 999) / 1000;
+        (*it).second = ((*it).second + 999) / 1000;
+    }
+    return list;
 }
 
 IntegerRangeList AbstractSensorChannelAdaptor::getAvailableBufferSizes() const

--- a/core/abstractsensor_a.h
+++ b/core/abstractsensor_a.h
@@ -126,6 +126,12 @@ public Q_SLOTS: // METHODS
      */
     void setInterval(int sessionId, int interval_ms);
 
+    /** AbstractSensorChannel::setDataRate(int, double)
+     *
+     *  Will also configure interval for the data connection.
+     */
+    void setDataRate(int sessionId, double dataRate_Hz);
+
     /** AbstractSensorChannel::getAvailableIntervals() */
     DataRangeList getAvailableIntervals();
 

--- a/core/abstractsensor_a.h
+++ b/core/abstractsensor_a.h
@@ -124,7 +124,7 @@ public Q_SLOTS: // METHODS
      *
      *  Will also configure interval for the data connection.
      */
-    void setInterval(int sessionId, int value);
+    void setInterval(int sessionId, int interval_ms);
 
     /** AbstractSensorChannel::getAvailableIntervals() */
     DataRangeList getAvailableIntervals();
@@ -138,13 +138,13 @@ public Q_SLOTS: // METHODS
     /** AbstractSensorChannel::setDownsampling(int, bool) */
     void setDownsampling(int sessionId, bool value);
 
-    /** AbstractSensorChannel::isValid(int, unsigned int)
+    /** AbstractSensorChannel::setBufferInterval(int, unsigned int)
      *
      *  Will also configure buffer interval for the data connection.
      */
-    void setBufferInterval(int sessionId, unsigned int value);
+    void setBufferInterval(int sessionId, unsigned int interval_ms);
 
-    /** AbstractSensorChannel::isValid(int, unsigned int)
+    /** AbstractSensorChannel::setBufferSize(int, unsigned int)
      *
      *  Will also configure buffer size for the data connection.
      */

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -962,6 +962,7 @@ bool HybrisManager::setDelay(int handle, int delay_ms, bool force)
         if (!force && state->m_delay == delay_ms) {
             sensordLogT("HYBRIS CTL setDelay(%d=%s, %d) -> no-change",
                         sensor->handle, sensorTypeName(sensor->type), delay_ms);
+            success = true;
         } else {
             int64_t delay_ns = delay_ms * 1000LL * 1000LL;
 #ifdef USE_BINDER

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -132,9 +132,9 @@ static void ObtainTemporaryWakeLock()
  * ========================================================================= */
 
 HybrisSensorState::HybrisSensorState()
-    : m_minDelay_ms(0)
-    , m_maxDelay_ms(0)
-    , m_delay_ms(-1)
+    : m_minDelay_us(0)
+    , m_maxDelay_us(0)
+    , m_delay_us(-1)
     , m_active(-1)
 {
     memset(&m_fallbackEvent, 0, sizeof m_fallbackEvent);
@@ -284,16 +284,16 @@ void HybrisManager::initManager()
 #endif
 
         if (use) {
-            // min/max delay is specified in [us] -> convert to [ms]
-            int minDelay_ms = (m_sensorArray[i].minDelay + 999) / 1000;
-            int maxDelay_ms = -1; // Assume: not defined by hal
+            // min/max delay in hal is specified in [us]
+            int minDelay_us = m_sensorArray[i].minDelay;
+            int maxDelay_us = -1; // Assume: not defined by hal
 
 #ifdef USE_BINDER
-            maxDelay_ms = (m_sensorArray[i].maxDelay + 999) / 1000;
+            maxDelay_us = m_sensorArray[i].maxDelay;
 #else
 #ifdef SENSORS_DEVICE_API_VERSION_1_3
             if (m_halDevice->common.version >= SENSORS_DEVICE_API_VERSION_1_3)
-                maxDelay_ms = (m_sensorArray[i].maxDelay + 999) / 1000;
+                maxDelay_us = m_sensorArray[i].maxDelay;
 #endif
 #endif
 
@@ -305,10 +305,10 @@ void HybrisManager::initManager()
              * For now use: minDelay * 2, but at least 1000 ms.
              */
 
-            if (maxDelay_ms < 0 && minDelay_ms > 0) {
-                maxDelay_ms = (minDelay_ms < 500) ? 1000 : (minDelay_ms * 2);
-                sensordLogD("hal does not specify maxDelay, fallback: %d ms",
-                            maxDelay_ms);
+            if (maxDelay_us < 0 && minDelay_us > 0) {
+                maxDelay_us = (minDelay_us < 500000) ? 1000000 : (minDelay_us * 2);
+                sensordLogD("hal does not specify maxDelay, fallback: %d us",
+                            maxDelay_us);
             }
 
             // Positive minDelay means delay /can/ be set - but depending
@@ -318,25 +318,25 @@ void HybrisManager::initManager()
             // failing to explicitly set delays / using delays that would
             // get rejected by upper levels of sensorfwd logic -> setup
             // 200 ms delay (capped to reported min/max range).
-            if (minDelay_ms >= 0) {
-                if (maxDelay_ms < minDelay_ms)
-                    maxDelay_ms = minDelay_ms;
+            if (minDelay_us >= 0) {
+                if (maxDelay_us < minDelay_us)
+                    maxDelay_us = minDelay_us;
 
-                int delay_ms = minDelay_ms ? 200 : 0;
-                if (delay_ms < minDelay_ms)
-                    delay_ms = minDelay_ms;
-                else if (delay_ms > maxDelay_ms)
-                    delay_ms = maxDelay_ms;
+                int delay_us = minDelay_us ? 200000 : 0;
+                if (delay_us < minDelay_us)
+                    delay_us = minDelay_us;
+                else if (delay_us > maxDelay_us)
+                    delay_us = maxDelay_us;
 
-                m_sensorState[i].m_minDelay_ms = minDelay_ms;
-                m_sensorState[i].m_maxDelay_ms = maxDelay_ms;
+                m_sensorState[i].m_minDelay_us = minDelay_us;
+                m_sensorState[i].m_maxDelay_us = maxDelay_us;
 
-                setDelay(m_sensorArray[i].handle, delay_ms, true);
+                setDelay(m_sensorArray[i].handle, delay_us, true);
 
                 sensordLogD("delay = %d [%d, %d]",
-                            m_sensorState[i].m_delay_ms,
-                            m_sensorState[i].m_minDelay_ms,
-                            m_sensorState[i].m_maxDelay_ms);
+                            m_sensorState[i].m_delay_us,
+                            m_sensorState[i].m_minDelay_us,
+                            m_sensorState[i].m_maxDelay_us);
             }
             m_indexOfType.insert(m_sensorArray[i].type, i);
 
@@ -901,56 +901,56 @@ float HybrisManager::getResolution(int handle) const
 
 int HybrisManager::getMinDelay(int handle) const
 {
-    int delay_ms = 0;
+    int delay_us = 0;
     int index = indexForHandle(handle);
 
     if (index != -1) {
         const struct sensor_t *sensor = &m_sensorArray[index];
         HybrisSensorState     *state  = &m_sensorState[index];
 
-        delay_ms = state->m_minDelay_ms;
+        delay_us = state->m_minDelay_us;
         sensordLogT("HYBRIS CTL getMinDelay(%d=%s) -> %d",
-                    sensor->handle, sensorTypeName(sensor->type), delay_ms);
+                    sensor->handle, sensorTypeName(sensor->type), delay_us);
     }
 
-    return delay_ms;
+    return delay_us;
 }
 
 int HybrisManager::getMaxDelay(int handle) const
 {
-    int delay_ms = 0;
+    int delay_us = 0;
     int index = indexForHandle(handle);
 
     if (index != -1) {
         const struct sensor_t *sensor = &m_sensorArray[index];
         HybrisSensorState     *state  = &m_sensorState[index];
 
-        delay_ms = state->m_maxDelay_ms;
+        delay_us = state->m_maxDelay_us;
         sensordLogT("HYBRIS CTL getMaxDelay(%d=%s) -> %d",
-                    sensor->handle, sensorTypeName(sensor->type), delay_ms);
+                    sensor->handle, sensorTypeName(sensor->type), delay_us);
     }
 
-    return delay_ms;
+    return delay_us;
 }
 
 int HybrisManager::getDelay(int handle) const
 {
-    int delay_ms = 0;
+    int delay_us = 0;
     int index = indexForHandle(handle);
 
     if (index != -1) {
         const struct sensor_t *sensor = &m_sensorArray[index];
         HybrisSensorState     *state  = &m_sensorState[index];
 
-        delay_ms = state->m_delay_ms;
+        delay_us = state->m_delay_us;
         sensordLogT("HYBRIS CTL getDelay(%d=%s) -> %d",
-                    sensor->handle, sensorTypeName(sensor->type), delay_ms);
+                    sensor->handle, sensorTypeName(sensor->type), delay_us);
     }
 
-    return delay_ms;
+    return delay_us;
 }
 
-bool HybrisManager::setDelay(int handle, int delay_ms, bool force)
+bool HybrisManager::setDelay(int handle, int delay_us, bool force)
 {
     bool success = false;
     int index = indexForHandle(handle);
@@ -959,12 +959,12 @@ bool HybrisManager::setDelay(int handle, int delay_ms, bool force)
         const struct sensor_t *sensor = &m_sensorArray[index];
         HybrisSensorState     *state  = &m_sensorState[index];
 
-        if (!force && state->m_delay_ms == delay_ms) {
+        if (!force && state->m_delay_us == delay_us) {
             sensordLogT("HYBRIS CTL setDelay(%d=%s, %d) -> no-change",
-                        sensor->handle, sensorTypeName(sensor->type), delay_ms);
+                        sensor->handle, sensorTypeName(sensor->type), delay_us);
             success = true;
         } else {
-            int64_t delay_ns = delay_ms * 1000LL * 1000LL;
+            int64_t delay_ns = delay_us * 1000LL;
 #ifdef USE_BINDER
             int error;
             GBinderLocalRequest *req = gbinder_client_new_request2(m_client, BATCH);
@@ -996,12 +996,12 @@ bool HybrisManager::setDelay(int handle, int delay_ms, bool force)
 #endif
             if (error) {
                 sensordLogW("HYBRIS CTL setDelay(%d=%s, %d) -> %d=%s",
-                            sensor->handle, sensorTypeName(sensor->type), delay_ms,
+                            sensor->handle, sensorTypeName(sensor->type), delay_us,
                             error, strerror(error));
             } else {
                 sensordLogD("HYBRIS CTL setDelay(%d=%s, %d) -> success",
-                            sensor->handle, sensorTypeName(sensor->type), delay_ms);
-                state->m_delay_ms = delay_ms;
+                            sensor->handle, sensorTypeName(sensor->type), delay_us);
+                state->m_delay_us = delay_us;
                 success = true;
             }
         }
@@ -1042,11 +1042,11 @@ bool HybrisManager::setActive(int handle, bool active)
             success = true;
         } else {
 #ifdef USE_BINDER
-            if (active && state->m_delay_ms != -1) {
+            if (active && state->m_delay_us != -1) {
                 sensordLogD("HYBRIS CTL FORCE PRE UPDATE %i, %s", sensor->handle, sensorTypeName(sensor->type));
-                int delay_ms = state->m_delay_ms;
-                state->m_delay_ms = -1;
-                setDelay(handle, delay_ms, true);
+                int delay_us = state->m_delay_us;
+                state->m_delay_us = -1;
+                setDelay(handle, delay_us, true);
             }
             int error;
             GBinderLocalRequest *req = gbinder_client_new_request2(m_client, ACTIVATE);
@@ -1086,11 +1086,11 @@ bool HybrisManager::setActive(int handle, bool active)
                 success = true;
             }
 #ifndef USE_BINDER
-            if (state->m_active == true && state->m_delay_ms != -1) {
+            if (state->m_active == true && state->m_delay_us != -1) {
                 sensordLogD("HYBRIS CTL FORCE DELAY UPDATE");
-                int delay_ms = state->m_delay_ms;
-                state->m_delay_ms = -1;
-                setDelay(handle, delay_ms, false);
+                int delay_us = state->m_delay_us;
+                state->m_delay_us = -1;
+                setDelay(handle, delay_us, false);
             }
 #endif
         }
@@ -1379,11 +1379,11 @@ unsigned int HybrisAdaptor::interval() const
     return hybrisManager()->getDelay(m_sensorHandle);
 }
 
-bool HybrisAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
+bool HybrisAdaptor::setInterval(const int sessionId, const unsigned int interval_us)
 {
     Q_UNUSED(sessionId);
 
-    bool ok = hybrisManager()->setDelay(m_sensorHandle, interval_ms, false);
+    bool ok = hybrisManager()->setDelay(m_sensorHandle, interval_us, false);
 
     if (!ok) {
         sensordLogW() << Q_FUNC_INFO << "setInterval not ok";

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -1379,7 +1379,7 @@ unsigned int HybrisAdaptor::interval() const
     return hybrisManager()->getDelay(m_sensorHandle);
 }
 
-bool HybrisAdaptor::setInterval(const unsigned int value, const int sessionId)
+bool HybrisAdaptor::setInterval(const int sessionId, const unsigned int value)
 {
     Q_UNUSED(sessionId);
 

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -1404,31 +1404,6 @@ bool HybrisAdaptor::setInterval(const int sessionId, const unsigned int interval
     return ok;
 }
 
-unsigned int HybrisAdaptor::evaluateIntervalRequests(int& sessionId) const
-{
-    if (m_intervalMap.size() == 0)
-    {
-        sessionId = -1;
-        return defaultInterval();
-    }
-
-    // Get the smallest positive request, 0 is reserved for HW wakeup
-    QMap<int, unsigned int>::const_iterator it = m_intervalMap.constBegin();
-    unsigned int highestValue = it.value();
-    int winningSessionId = it.key();
-
-    for (++it; it != m_intervalMap.constEnd(); ++it)
-    {
-        if (((it.value() < highestValue) && (it.value() > 0)) || highestValue == 0) {
-            highestValue = it.value();
-            winningSessionId = it.key();
-        }
-    }
-
-    sessionId = winningSessionId;
-    return highestValue > 0 ? highestValue : defaultInterval();
-}
-
 /* ------------------------------------------------------------------------- *
  * start/stop adaptor
  * ------------------------------------------------------------------------- */

--- a/core/hybrisadaptor.h
+++ b/core/hybrisadaptor.h
@@ -275,7 +275,6 @@ protected:
 
     virtual unsigned int interval() const;
     virtual bool setInterval(const int sessionId, const unsigned int interval_us);
-    virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
     static bool writeToFile(const QByteArray& path, const QByteArray& content);
 
 private:

--- a/core/hybrisadaptor.h
+++ b/core/hybrisadaptor.h
@@ -139,9 +139,9 @@ struct HybrisSensorState
     HybrisSensorState();
     ~HybrisSensorState();
 
-    int  m_minDelay;
-    int  m_maxDelay;
-    int  m_delay;
+    int  m_minDelay_ms;
+    int  m_maxDelay_ms;
+    int  m_delay_ms;
     int  m_active;
     sensors_event_t m_fallbackEvent;
 };
@@ -274,7 +274,7 @@ protected:
     unsigned int maxInterval() const;
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(const int sessionId, const unsigned int value);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
     virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
     static bool writeToFile(const QByteArray& path, const QByteArray& content);
 

--- a/core/hybrisadaptor.h
+++ b/core/hybrisadaptor.h
@@ -274,7 +274,7 @@ protected:
     unsigned int maxInterval() const;
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(const unsigned int value, const int sessionId);
+    virtual bool setInterval(const int sessionId, const unsigned int value);
     virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
     static bool writeToFile(const QByteArray& path, const QByteArray& content);
 

--- a/core/hybrisadaptor.h
+++ b/core/hybrisadaptor.h
@@ -139,9 +139,9 @@ struct HybrisSensorState
     HybrisSensorState();
     ~HybrisSensorState();
 
-    int  m_minDelay_ms;
-    int  m_maxDelay_ms;
-    int  m_delay_ms;
+    int  m_minDelay_us;
+    int  m_maxDelay_us;
+    int  m_delay_us;
     int  m_active;
     sensors_event_t m_fallbackEvent;
 };
@@ -170,7 +170,7 @@ public:
     int              getMinDelay   (int handle) const;
     int              getMaxDelay   (int handle) const;
     int              getDelay      (int handle) const;
-    bool             setDelay      (int handle, int delay_ms, bool force);
+    bool             setDelay      (int handle, int delay_us, bool force);
     bool             getActive     (int handle) const;
     bool             setActive     (int handle, bool active);
 
@@ -274,7 +274,7 @@ protected:
     unsigned int maxInterval() const;
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_us);
     virtual unsigned int evaluateIntervalRequests(int& sessionId) const;
     static bool writeToFile(const QByteArray& path, const QByteArray& content);
 

--- a/core/inputdevadaptor.cpp
+++ b/core/inputdevadaptor.cpp
@@ -45,11 +45,11 @@
 
 InputDevAdaptor::InputDevAdaptor(const QString& id, int maxDeviceCount) :
     SysfsAdaptor(id, SysfsAdaptor::SelectMode, false),
-    deviceCount_(0),
-    maxDeviceCount_(maxDeviceCount),
-    cachedInterval_(0)
+    m_deviceCount(0),
+    m_maxDeviceCount(maxDeviceCount),
+    m_cachedInterval_ms(0)
 {
-    memset(evlist_, 0x0, sizeof(input_event)*64);
+    memset(m_evlist, 0x0, sizeof(input_event)*64);
 }
 
 InputDevAdaptor::~InputDevAdaptor()
@@ -63,26 +63,26 @@ int InputDevAdaptor::getInputDevices(const QString& typeName)
     QString devicePollFilePath = SensorFrameworkConfig::configuration()->value("global/device_poll_file_path").toString();
 
     int deviceNumber = 0;
-    deviceString_ = typeName;
+    m_deviceString = typeName;
 
     // Check if this device name is defined in configuration
     QString deviceName = SensorFrameworkConfig::configuration()->value<QString>(typeName + "/device", "");
 
     // Do not perform strict checks for the input device
     if (deviceName.size() && checkInputDevice(deviceName, typeName, false)) {
-        addPath(deviceName, deviceCount_);
-        ++deviceCount_;
+        addPath(deviceName, m_deviceCount);
+        ++m_deviceCount;
     } else if(deviceSysPathString.contains("%1")) {
         const int MAX_EVENT_DEV = 16;
-qDebug() << deviceNumber << deviceCount_ << maxDeviceCount_;
+qDebug() << deviceNumber << m_deviceCount << m_maxDeviceCount;
 
         // No configuration for this device, try find the device from the device system path
-        while (deviceNumber < MAX_EVENT_DEV && deviceCount_ < maxDeviceCount_) {
+        while (deviceNumber < MAX_EVENT_DEV && m_deviceCount < m_maxDeviceCount) {
             deviceName = deviceSysPathString.arg(deviceNumber);
             qDebug() << Q_FUNC_INFO << deviceName;
             if (checkInputDevice(deviceName, typeName)) {
-                addPath(deviceName, deviceCount_);
-                ++deviceCount_;
+                addPath(deviceName, m_deviceCount);
+                ++m_deviceCount;
                 break;
             }
             ++deviceNumber;
@@ -91,26 +91,26 @@ qDebug() << deviceNumber << deviceCount_ << maxDeviceCount_;
 
     QString pollConfigKey = QString(typeName + "/poll_file");
     if (SensorFrameworkConfig::configuration()->exists(pollConfigKey)) {
-        usedDevicePollFilePath_ = SensorFrameworkConfig::configuration()->value<QString>(pollConfigKey, "");
+        m_usedDevicePollFilePath = SensorFrameworkConfig::configuration()->value<QString>(pollConfigKey, "");
     } else {
-        usedDevicePollFilePath_ = devicePollFilePath.arg(deviceNumber);
+        m_usedDevicePollFilePath = devicePollFilePath.arg(deviceNumber);
     }
-qDebug() << Q_FUNC_INFO << usedDevicePollFilePath_;
+qDebug() << Q_FUNC_INFO << m_usedDevicePollFilePath;
 
-    if (deviceCount_ == 0) {
+    if (m_deviceCount == 0) {
         sensordLogW() << "Cannot find any device for: " << typeName;
         setValid(false);
     } else {
-        QByteArray byteArray = readFromFile(usedDevicePollFilePath_.toLatin1());
-        cachedInterval_ = byteArray.size() > 0 ? byteArray.toInt() : 0;
+        QByteArray byteArray = readFromFile(m_usedDevicePollFilePath.toLatin1());
+        m_cachedInterval_ms = byteArray.size() > 0 ? byteArray.toInt() : 0;
     }
 
-    return deviceCount_;
+    return m_deviceCount;
 }
 
 int InputDevAdaptor::getEvents(int fd)
 {
-    int bytes = read(fd, evlist_, sizeof(struct input_event)*64);
+    int bytes = read(fd, m_evlist, sizeof(struct input_event)*64);
     if (bytes == -1) {
         sensordLogW() << "Error occured: " << strerror(errno);
         return 0;
@@ -127,12 +127,12 @@ void InputDevAdaptor::processSample(int pathId, int fd)
     int numEvents = getEvents(fd);
 
     for (int i = 0; i < numEvents; ++i) {
-        switch (evlist_[i].type) {
+        switch (m_evlist[i].type) {
             case EV_SYN:
-                interpretSync(pathId, &(evlist_[i]));
+                interpretSync(pathId, &(m_evlist[i]));
                 break;
             default:
-                interpretEvent(pathId, &(evlist_[i]));
+                interpretEvent(pathId, &(m_evlist[i]));
                 break;
         }
     }
@@ -171,18 +171,19 @@ qDebug() << Q_FUNC_INFO << path << matchString << strictChecks;
 
 unsigned int InputDevAdaptor::interval() const
 {
-    return cachedInterval_;
+    return m_cachedInterval_ms;
 }
 
-bool InputDevAdaptor::setInterval(const int sessionId, const unsigned int value)
+bool InputDevAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
 {
     Q_UNUSED(sessionId);
 
-    sensordLogD() << "Setting poll interval for " << deviceString_ << " to " << value;
-    QByteArray frequencyString(QString("%1\n").arg(value).toLocal8Bit());
-    if(writeToFile(usedDevicePollFilePath_.toLocal8Bit(), frequencyString))
+    // XXX: is this supposed to be sampling frequency or sample time?
+    sensordLogD() << "Setting poll interval for " << m_deviceString << " to " << interval_ms;
+    QByteArray frequencyString(QString("%1\n").arg(interval_ms).toLocal8Bit());
+    if(writeToFile(m_usedDevicePollFilePath.toLocal8Bit(), frequencyString))
     {
-        cachedInterval_ = value;
+        m_cachedInterval_ms = interval_ms;
         return true;
     }
     return false;
@@ -199,5 +200,5 @@ void InputDevAdaptor::init()
 
 int InputDevAdaptor::getDeviceCount() const
 {
-    return deviceCount_;
+    return m_deviceCount;
 }

--- a/core/inputdevadaptor.cpp
+++ b/core/inputdevadaptor.cpp
@@ -174,7 +174,7 @@ unsigned int InputDevAdaptor::interval() const
     return cachedInterval_;
 }
 
-bool InputDevAdaptor::setInterval(const unsigned int value, const int sessionId)
+bool InputDevAdaptor::setInterval(const int sessionId, const unsigned int value)
 {
     Q_UNUSED(sessionId);
 

--- a/core/inputdevadaptor.h
+++ b/core/inputdevadaptor.h
@@ -108,7 +108,7 @@ protected:
 
     virtual unsigned int interval() const;
 
-    virtual bool setInterval(const unsigned int value, const int sessionId);
+    virtual bool setInterval(const int sessionId, const unsigned int value);
 
 private:
     /**

--- a/core/inputdevadaptor.h
+++ b/core/inputdevadaptor.h
@@ -108,24 +108,24 @@ protected:
 
     virtual unsigned int interval() const;
 
-    virtual bool setInterval(const int sessionId, const unsigned int value);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
 
 private:
     /**
      * Read events from file descriptor. The read events are stored in
-     * #evlist_ array.
+     * #m_evlist array.
      *
      * @param fd File descriptor to read from.
      * @return Number of read events.
      */
     int getEvents(int fd);
 
-    QString usedDevicePollFilePath_; /**< sysfs path to input device poll file */
-    QString deviceString_;           /**< input device name */
-    int deviceCount_;                /**< number of available input devices */
-    const int maxDeviceCount_;       /**< maximum number of supported devices */
-    input_event evlist_[64];         /**< input event buffer */
-    unsigned int cachedInterval_;    /**< cached interval reading */
+    QString m_usedDevicePollFilePath; /**< sysfs path to input device poll file */
+    QString m_deviceString;           /**< input device name */
+    int m_deviceCount;                /**< number of available input devices */
+    const int m_maxDeviceCount;       /**< maximum number of supported devices */
+    input_event m_evlist[64];         /**< input event buffer */
+    unsigned int m_cachedInterval_ms; /**< cached interval reading */
 };
 
 #endif

--- a/core/inputdevadaptor.h
+++ b/core/inputdevadaptor.h
@@ -108,7 +108,7 @@ protected:
 
     virtual unsigned int interval() const;
 
-    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_us);
 
 private:
     /**
@@ -125,7 +125,7 @@ private:
     int m_deviceCount;                /**< number of available input devices */
     const int m_maxDeviceCount;       /**< maximum number of supported devices */
     input_event m_evlist[64];         /**< input event buffer */
-    unsigned int m_cachedInterval_ms; /**< cached interval reading */
+    unsigned int m_cachedInterval_us; /**< cached interval reading */
 };
 
 #endif

--- a/core/nodebase.cpp
+++ b/core/nodebase.cpp
@@ -314,23 +314,23 @@ unsigned int NodeBase::getInterval(int sessionId) const
     return it.value();
 }
 
-bool NodeBase::setIntervalRequest(const int sessionId, const unsigned int value)
+bool NodeBase::setIntervalRequest(const int sessionId, const unsigned int interval_ms)
 {
     // Has single defined source, pass the request that way
     if (!hasLocalInterval())
     {
-        return m_intervalSource->setIntervalRequest(sessionId, value);
+        return m_intervalSource->setIntervalRequest(sessionId, interval_ms);
     }
 
     // Validate interval request
-    if (!isValidIntervalRequest(value))
+    if (!isValidIntervalRequest(interval_ms))
     {
-        sensordLogW() << "Invalid interval requested for node '" << id() << "' by session '" << sessionId << "': " << value;
+        sensordLogW() << "Invalid interval requested for node '" << id() << "' by session '" << sessionId << "': " << interval_ms;
         return false;
     }
 
     // Store the request for the session
-    m_intervalMap[sessionId] = value;
+    m_intervalMap[sessionId] = interval_ms;
 
     // Store the current interval
     unsigned int previousInterval = interval();
@@ -455,14 +455,14 @@ unsigned int NodeBase::defaultInterval() const
     return m_defaultInterval;
 }
 
-bool NodeBase::setDefaultInterval(const unsigned int value)
+bool NodeBase::setDefaultInterval(const unsigned int interval_ms)
 {
-    if (!isValidIntervalRequest(value))
+    if (!isValidIntervalRequest(interval_ms))
     {
-        sensordLogW() << "Attempting to define invalid default data rate:" << value;
+        sensordLogW() << "Attempting to define invalid default data rate:" << interval_ms;
         return false;
     }
-    m_defaultInterval = value;
+    m_defaultInterval = interval_ms;
     m_hasDefault = true;
     return true;
 }
@@ -641,12 +641,12 @@ bool NodeBase::updateBufferSize()
     return false;
 }
 
-bool NodeBase::setBufferInterval(int sessionId, unsigned int value)
+bool NodeBase::setBufferInterval(int sessionId, unsigned int interval_ms)
 {
     bool hwbuffering = false;
-    if(!isInRange(value, getAvailableBufferIntervals(hwbuffering)))
+    if(!isInRange(interval_ms, getAvailableBufferIntervals(hwbuffering)))
         return false;
-    m_bufferIntervalMap.insert(sessionId, value);
+    m_bufferIntervalMap.insert(sessionId, interval_ms);
     return updateBufferInterval();
 }
 
@@ -728,9 +728,9 @@ unsigned int NodeBase::interval() const
     return 0;
 }
 
-bool NodeBase::setInterval(int sessionId, unsigned int value)
+bool NodeBase::setInterval(int sessionId, unsigned int interval_ms)
 {
-    Q_UNUSED(value);
+    Q_UNUSED(interval_ms);
     Q_UNUSED(sessionId);
     sensordLogD() << __func__ << "not implemented in some node using it.";
     return false;
@@ -743,9 +743,9 @@ bool NodeBase::setBufferSize(unsigned int value)
     return false;
 }
 
-bool NodeBase::setBufferInterval(unsigned int value)
+bool NodeBase::setBufferInterval(unsigned int interval_ms)
 {
-    Q_UNUSED(value);
+    Q_UNUSED(interval_ms);
     sensordLogD() << __func__ << "not implemented in some node using it.";
     return false;
 }

--- a/core/nodebase.cpp
+++ b/core/nodebase.cpp
@@ -31,13 +31,10 @@
 
 NodeBase::NodeBase(const QString& id, QObject* parent) :
     QObject(parent),
-    m_bufferSize(0),
-    m_bufferInterval(0),
     m_dataRangeSource(NULL),
     m_intervalSource(NULL),
     m_hasDefault(false),
     m_defaultInterval_us(0),
-    DEFAULT_DATA_RANGE_REQUEST(-1),
     id_(id),
     isValid_(false)
 {

--- a/core/nodebase.cpp
+++ b/core/nodebase.cpp
@@ -35,8 +35,8 @@ NodeBase::NodeBase(const QString& id, QObject* parent) :
     m_intervalSource(NULL),
     m_hasDefault(false),
     m_defaultInterval_us(0),
-    id_(id),
-    isValid_(false)
+    m_id(id),
+    m_isValid(false)
 {
 }
 
@@ -46,12 +46,12 @@ NodeBase::~NodeBase()
 
 const QString& NodeBase::id() const
 {
-    return id_;
+    return m_id;
 }
 
 bool NodeBase::isValid() const
 {
-    return isValid_;
+    return m_isValid;
 }
 
 bool NodeBase::isMetadataValid() const
@@ -77,7 +77,7 @@ void NodeBase::introduceAvailableDataRange(const DataRange& range)
 {
     if (!m_dataRangeList.contains(range))
     {
-        sensordLogD() << "Introduced new data range for '" << id_ << "':" << range.min << "-" << range.max << "," << range.resolution;
+        sensordLogD() << "Introduced new data range for '" << id() << "':" << range.min << "-" << range.max << "," << range.resolution;
         m_dataRangeList.append(range);
     }
 }
@@ -270,7 +270,7 @@ void NodeBase::introduceAvailableInterval(const DataRange& interval)
 {
     if (!m_intervalList.contains(interval))
     {
-        sensordLogD() << "Introduced new interval for '" << id_ << "':" << interval.min << "-" << interval.max;
+        sensordLogD() << "Introduced new interval for '" << id() << "':" << interval.min << "-" << interval.max;
         m_intervalList.append(interval);
     }
 }
@@ -734,8 +734,8 @@ void NodeBase::removeSession(int sessionId)
 
 void NodeBase::setValid(bool valid)
 {
-    isValid_ = valid;
-    if(!isValid_)
+    m_isValid = valid;
+    if(!m_isValid)
     {
         sensordLogW() << "Node '" << id() << "' state changed to invalid";
     }

--- a/core/nodebase.cpp
+++ b/core/nodebase.cpp
@@ -341,7 +341,7 @@ bool NodeBase::setIntervalRequest(const int sessionId, const unsigned int value)
 
     if (winningSessionId >= 0) {
         sensordLogD() << "Setting new interval for node: " << id() << ". Evaluation won by session '" << winningSessionId << "' with request: " << winningRequest;
-        setInterval(winningRequest, winningSessionId);
+        setInterval(winningSessionId, winningRequest);
     }
 
     // Signal listeners about change
@@ -502,7 +502,7 @@ void NodeBase::removeIntervalRequest(const int sessionId)
         int winningSessionId;
         unsigned int winningRequest = evaluateIntervalRequests(winningSessionId);
         if (winningSessionId >= 0) {
-            setInterval(winningRequest, winningSessionId);
+            setInterval(winningSessionId, winningRequest);
         }
 
         // Signal listeners if changed.
@@ -728,7 +728,7 @@ unsigned int NodeBase::interval() const
     return 0;
 }
 
-bool NodeBase::setInterval(unsigned int value, int sessionId)
+bool NodeBase::setInterval(int sessionId, unsigned int value)
 {
     Q_UNUSED(value);
     Q_UNUSED(sessionId);

--- a/core/nodebase.h
+++ b/core/nodebase.h
@@ -182,7 +182,7 @@ public Q_SLOTS:
      * @param value interval value is milliseconds.
      * @return was request succesful.
      */
-    bool setIntervalRequest(int sessionId, unsigned int value);
+    bool setIntervalRequest(int sessionId, unsigned int interval_ms);
 
     /**
      * Request default interval for the node.
@@ -276,7 +276,7 @@ public Q_SLOTS:
      * @param value interval in milliseconds.
      * @return was interval se succesfully.
      */
-    bool setBufferInterval(int sessionId, unsigned int value);
+    bool setBufferInterval(int sessionId, unsigned int interval_ms);
 
     /**
      * Clear buffer interval requests of given session.
@@ -431,7 +431,7 @@ protected:
      * @param sessionId Session ID.
      * @return was interval set succesfully.
      */
-    virtual bool setInterval(int sessionId, unsigned int value);
+    virtual bool setInterval(int sessionId, unsigned int interval_ms);
 
     /**
      * Does node have locally set interval.
@@ -474,7 +474,7 @@ protected:
      * @param value Value to use as default interval.
      * @return was interval set succesfully.
      */
-    bool setDefaultInterval(unsigned int value);
+    bool setDefaultInterval(unsigned int interval_ms);
 
     /**
      * Validate an interval request.
@@ -508,7 +508,7 @@ protected:
      * @param value buffer interval.
      * @return was buffer interval set succesfully.
      */
-    virtual bool setBufferInterval(unsigned int value);
+    virtual bool setBufferInterval(unsigned int interval_ms);
 
     QMap<int, unsigned int> m_intervalMap;    /**< active interval requests for sessions */
 

--- a/core/nodebase.h
+++ b/core/nodebase.h
@@ -182,7 +182,7 @@ public Q_SLOTS:
      * @param value interval value is milliseconds.
      * @return was request succesful.
      */
-    bool setIntervalRequest(int sessionId, unsigned int interval_ms);
+    bool setIntervalRequest(int sessionId, unsigned int interval_us);
 
     /**
      * Request default interval for the node.
@@ -248,7 +248,7 @@ public Q_SLOTS:
     /**
      * Get current buffer interval of the node.
      *
-     * @return current buffer interval in milliseconds.
+     * @return current buffer interval in microseconds.
      */
     virtual unsigned int bufferInterval() const { return 0; }
 
@@ -276,7 +276,7 @@ public Q_SLOTS:
      * @param value interval in milliseconds.
      * @return was interval se succesfully.
      */
-    bool setBufferInterval(int sessionId, unsigned int interval_ms);
+    bool setBufferInterval(int sessionId, unsigned int interval_us);
 
     /**
      * Clear buffer interval requests of given session.
@@ -431,7 +431,7 @@ protected:
      * @param sessionId Session ID.
      * @return was interval set succesfully.
      */
-    virtual bool setInterval(int sessionId, unsigned int interval_ms);
+    virtual bool setInterval(int sessionId, unsigned int interval_us);
 
     /**
      * Does node have locally set interval.
@@ -474,7 +474,7 @@ protected:
      * @param value Value to use as default interval.
      * @return was interval set succesfully.
      */
-    bool setDefaultInterval(unsigned int interval_ms);
+    bool setDefaultInterval(unsigned int interval_us);
 
     /**
      * Validate an interval request.
@@ -508,7 +508,7 @@ protected:
      * @param value buffer interval.
      * @return was buffer interval set succesfully.
      */
-    virtual bool setBufferInterval(unsigned int interval_ms);
+    virtual bool setBufferInterval(unsigned int interval_us);
 
     QMap<int, unsigned int> m_intervalMap;    /**< active interval requests for sessions */
 

--- a/core/nodebase.h
+++ b/core/nodebase.h
@@ -512,9 +512,6 @@ protected:
 
     QMap<int, unsigned int> m_intervalMap;    /**< active interval requests for sessions */
 
-    unsigned int            m_bufferSize;     /** buffer size */
-    unsigned int            m_bufferInterval; /** buffer interval */
-
 private:
     /**
      * Returns whether the class defines its own output data range, or
@@ -565,8 +562,6 @@ private:
     //Oldest session wins for these:
     QMap<int, unsigned int> m_bufferSizeMap; /**< buffersize requests for sessions. */
     QMap<int, unsigned int> m_bufferIntervalMap; /**< buffer interval requests for sessions. */
-
-    const DataRangeRequest  DEFAULT_DATA_RANGE_REQUEST; /**< default data range request */
 
     QString                 id_; /**< node ID */
     bool                    isValid_; /**< is node correctly initialized */

--- a/core/nodebase.h
+++ b/core/nodebase.h
@@ -563,8 +563,8 @@ private:
     QMap<int, unsigned int> m_bufferSizeMap; /**< buffersize requests for sessions. */
     QMap<int, unsigned int> m_bufferIntervalMap; /**< buffer interval requests for sessions. */
 
-    QString                 id_; /**< node ID */
-    bool                    isValid_; /**< is node correctly initialized */
+    QString                 m_id; /**< node ID */
+    bool                    m_isValid; /**< is node correctly initialized */
 };
 
 #endif

--- a/core/nodebase.h
+++ b/core/nodebase.h
@@ -482,7 +482,7 @@ protected:
      * @param value Value to validate.
      * @return is valid request.
      */
-    bool isValidIntervalRequest(unsigned int value) const;
+    unsigned int validateIntervalRequest(unsigned int interval_us) const;
 
     /**
      * Find buffer with given name.
@@ -558,7 +558,7 @@ private:
     QList<DataRange>        m_intervalList;   /**< available intervals */
     NodeBase*               m_intervalSource; /**< interval sources */
     bool                    m_hasDefault;     /**< does node have locally set interval */
-    unsigned int            m_defaultInterval; /**< locally set interval */
+    unsigned int            m_defaultInterval_us; /**< locally set interval */
 
     QList<NodeBase*>        m_sourceList; /**< source nodes */
 

--- a/core/nodebase.h
+++ b/core/nodebase.h
@@ -431,7 +431,7 @@ protected:
      * @param sessionId Session ID.
      * @return was interval set succesfully.
      */
-    virtual bool setInterval(unsigned int value, int sessionId);
+    virtual bool setInterval(int sessionId, unsigned int value);
 
     /**
      * Does node have locally set interval.

--- a/core/sockethandler.h
+++ b/core/sockethandler.h
@@ -92,7 +92,7 @@ public:
      *
      * @param interval Interval in milliseconds.
      */
-    void setInterval(int interval);
+    void setInterval(int interval_ms);
 
     /**
      * Get used interval for the data stream.
@@ -122,7 +122,7 @@ public:
      *
      * @param interval interval in milliseconds.
      */
-    void setBufferInterval(unsigned int interval);
+    void setBufferInterval(unsigned int interval_ms);
 
     /**
      * Get buffer inteval for the data stream.
@@ -171,16 +171,16 @@ private:
      */
     bool delayedWrite();
 
-    QLocalSocket* socket;        /**< socket pointer. */
-    int interval;                /**< interval in milliseconds. */
-    char* buffer;                /**< pointer to buffer allocation. */
-    int size;                    /**< allocated buffer size. */
-    unsigned int count;          /**< how many elements are in the buffer */
-    struct timeval lastWrite;    /**< when data was written last time */
-    QTimer timer;                /**< timer for delayed write */
-    unsigned int bufferSize;     /**< buffer size */
-    unsigned int bufferInterval; /**< buffer interval in milliseconds */
-    bool downsampling;           /**< sample dropping */
+    QLocalSocket *m_socket;           /**< socket pointer. */
+    int m_interval_ms;                /**< interval in milliseconds. */
+    char *m_buffer;                   /**< pointer to buffer allocation. */
+    int m_size;                       /**< allocated buffer size. */
+    unsigned int m_count;             /**< how many elements are in the buffer */
+    struct timeval m_lastWrite;       /**< when data was written last time */
+    QTimer m_timer;                   /**< timer for delayed write */
+    unsigned int m_bufferSize;        /**< buffer size */
+    unsigned int m_bufferInterval_ms; /**< buffer interval in milliseconds */
+    bool m_downsampling;              /**< sample dropping */
 
 private slots:
 
@@ -260,7 +260,7 @@ public:
      * @param sessionId Session ID.
      * @param value Interval in milliseconds.
      */
-    void setInterval(int sessionId, int value);
+    void setInterval(int sessionId, int interval_ms);
 
     /**
      * Remove set interval from given session.
@@ -310,7 +310,7 @@ public:
      * @param sessionId Session ID.
      * @param value buffer inteval in milliseconds.
      */
-    void setBufferInterval(int sessionId, unsigned int value);
+    void setBufferInterval(int sessionId, unsigned int interval_ms);
 
     /**
      * Remove set buffer inteval for given session.

--- a/core/sockethandler.h
+++ b/core/sockethandler.h
@@ -92,7 +92,7 @@ public:
      *
      * @param interval Interval in milliseconds.
      */
-    void setInterval(int interval_ms);
+    void setInterval(int interval_us);
 
     /**
      * Get used interval for the data stream.
@@ -122,7 +122,7 @@ public:
      *
      * @param interval interval in milliseconds.
      */
-    void setBufferInterval(unsigned int interval_ms);
+    void setBufferInterval(unsigned int interval_us);
 
     /**
      * Get buffer inteval for the data stream.
@@ -172,14 +172,14 @@ private:
     bool delayedWrite();
 
     QLocalSocket *m_socket;           /**< socket pointer. */
-    int m_interval_ms;                /**< interval in milliseconds. */
+    int m_interval_us;                /**< interval in milliseconds. */
     char *m_buffer;                   /**< pointer to buffer allocation. */
     int m_size;                       /**< allocated buffer size. */
     unsigned int m_count;             /**< how many elements are in the buffer */
     struct timeval m_lastWrite;       /**< when data was written last time */
     QTimer m_timer;                   /**< timer for delayed write */
     unsigned int m_bufferSize;        /**< buffer size */
-    unsigned int m_bufferInterval_ms; /**< buffer interval in milliseconds */
+    unsigned int m_bufferInterval_us; /**< buffer interval in milliseconds */
     bool m_downsampling;              /**< sample dropping */
 
 private slots:
@@ -260,7 +260,7 @@ public:
      * @param sessionId Session ID.
      * @param value Interval in milliseconds.
      */
-    void setInterval(int sessionId, int interval_ms);
+    void setInterval(int sessionId, int interval_us);
 
     /**
      * Remove set interval from given session.
@@ -310,7 +310,7 @@ public:
      * @param sessionId Session ID.
      * @param value buffer inteval in milliseconds.
      */
-    void setBufferInterval(int sessionId, unsigned int interval_ms);
+    void setBufferInterval(int sessionId, unsigned int interval_us);
 
     /**
      * Remove set buffer inteval for given session.
@@ -324,7 +324,7 @@ public:
      * #SessionData::bufferInterval().
      *
      * @param sessionId Session ID.
-     * @return interval in milliseconds.
+     * @return interval in microseconds.
      */
     unsigned int bufferInterval(int sessionId) const;
 

--- a/core/sysfsadaptor.cpp
+++ b/core/sysfsadaptor.cpp
@@ -384,7 +384,7 @@ unsigned int SysfsAdaptor::interval() const
     return interval_;
 }
 
-bool SysfsAdaptor::setInterval(const unsigned int value, const int sessionId)
+bool SysfsAdaptor::setInterval(const int sessionId, const unsigned int value)
 {
     Q_UNUSED(sessionId);
     if(!checkIntervalUsage())

--- a/core/sysfsadaptor.cpp
+++ b/core/sysfsadaptor.cpp
@@ -46,7 +46,7 @@ SysfsAdaptor::SysfsAdaptor(const QString& id,
     m_reader(this),
     m_mode(mode),
     m_epollDescriptor(-1),
-    m_interval_ms(0),
+    m_interval_us(0),
     m_inStandbyMode(false),
     m_running(false),
     m_shouldBeRunning(false),
@@ -381,15 +381,15 @@ unsigned int SysfsAdaptor::interval() const
 {
     if(!checkIntervalUsage())
         return 0;
-    return m_interval_ms;
+    return m_interval_us;
 }
 
-bool SysfsAdaptor::setInterval(const int sessionId, const unsigned int interval_ms)
+bool SysfsAdaptor::setInterval(const int sessionId, const unsigned int interval_us)
 {
     Q_UNUSED(sessionId);
     if(!checkIntervalUsage())
         return false;
-    m_interval_ms = interval_ms;
+    m_interval_us = interval_us;
     return true;
 }
 
@@ -492,5 +492,9 @@ void SysfsAdaptor::init()
 
     introduceAvailableDataRanges(name());
     introduceAvailableIntervals(name());
-    setDefaultInterval(SensorFrameworkConfig::configuration()->value<int>(name() + "/default_interval", 0));
+    int interval_ms = SensorFrameworkConfig::configuration()->value<int>(name() + "/default_interval", 0);
+    if (interval_ms > 0) {
+        unsigned int interval_us = (unsigned int)interval_ms * 1000u;
+        setDefaultInterval(interval_us);
+    }
 }

--- a/core/sysfsadaptor.h
+++ b/core/sysfsadaptor.h
@@ -204,7 +204,7 @@ protected:
      *        to allow for proper state maintenance.
      * @return \c true on successfull set (valid value), \c false otherwise.
      */
-    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_us);
 
     /**
      * Tells which mode the adaptor is using for getting input.
@@ -251,7 +251,7 @@ private:
     int                 m_pipeDescriptors[2]; /**< open pipe descriptors */
     QStringList         m_paths;   /**< added paths. */
     QList<int>          m_pathIds; /**< added path IDs. */
-    unsigned int m_interval_ms; /**< used interval */
+    unsigned int m_interval_us; /**< used interval */
     bool m_inStandbyMode;    /**< are we in standby */
     bool m_running;          /**< are we running */
     bool m_shouldBeRunning;  /**< should we be running */

--- a/core/sysfsadaptor.h
+++ b/core/sysfsadaptor.h
@@ -204,7 +204,7 @@ protected:
      *        to allow for proper state maintenance.
      * @return \c true on successfull set (valid value), \c false otherwise.
      */
-    virtual bool setInterval(const unsigned int value, const int sessionId);
+    virtual bool setInterval(const int sessionId, const unsigned int value);
 
     /**
      * Tells which mode the adaptor is using for getting input.

--- a/core/sysfsadaptor.h
+++ b/core/sysfsadaptor.h
@@ -73,8 +73,8 @@ public:
     void startReader();
 
 private:
-    bool          running_; /**< should thread be running or not */
-    SysfsAdaptor *parent_;  /**< parent object. */
+    bool          m_running; /**< should thread be running or not */
+    SysfsAdaptor *m_parent;  /**< parent object. */
 };
 
 /**
@@ -204,7 +204,7 @@ protected:
      *        to allow for proper state maintenance.
      * @return \c true on successfull set (valid value), \c false otherwise.
      */
-    virtual bool setInterval(const int sessionId, const unsigned int value);
+    virtual bool setInterval(const int sessionId, const unsigned int interval_ms);
 
     /**
      * Tells which mode the adaptor is using for getting input.
@@ -245,19 +245,19 @@ private:
      */
     bool checkIntervalUsage() const;
 
-    SysfsAdaptorReader  reader_; /**< reader thread instance */
-    PollMode            mode_;   /**< used poll mode */
-    int                 epollDescriptor_;    /**< open epoll descriptors */
-    int                 pipeDescriptors_[2]; /**< open pipe descriptors */
-    QStringList         paths_;   /**< added paths. */
-    QList<int>          pathIds_; /**< added path IDs. */
-    unsigned int interval_; /**< used interval */
-    bool inStandbyMode_;    /**< are we in standby */
-    bool running_;          /**< are we running */
-    bool shouldBeRunning_;  /**< should we be running */
-    bool doSeek_;           /**< should lseek() be performed after reading */
-    QList<int> sysfsDescriptors_; /**< List of open file descriptors. */
-    QMutex mutex_;          /** mutex protecting starting and stopping. */
+    SysfsAdaptorReader  m_reader; /**< reader thread instance */
+    PollMode            m_mode;   /**< used poll mode */
+    int                 m_epollDescriptor;    /**< open epoll descriptors */
+    int                 m_pipeDescriptors[2]; /**< open pipe descriptors */
+    QStringList         m_paths;   /**< added paths. */
+    QList<int>          m_pathIds; /**< added path IDs. */
+    unsigned int m_interval_ms; /**< used interval */
+    bool m_inStandbyMode;    /**< are we in standby */
+    bool m_running;          /**< are we running */
+    bool m_shouldBeRunning;  /**< should we be running */
+    bool m_doSeek;           /**< should lseek() be performed after reading */
+    QList<int> m_sysfsDescriptors; /**< List of open file descriptors. */
+    QMutex m_mutex;          /**< mutex protecting starting and stopping. */
 
     friend class SysfsAdaptorReader;
 };

--- a/filters/declinationfilter/declinationfilter.h
+++ b/filters/declinationfilter/declinationfilter.h
@@ -63,12 +63,12 @@ private:
 
     void loadSettings();
 
-    CompassData orientation_;
-    QAtomicInt declinationCorrection_;
-    quint64 lastUpdate_;
-    quint64 updateInterval_;
+    CompassData m_orientation;
+    QAtomicInt m_declinationCorrection;
+    quint64 m_lastUpdate_us;
+    quint64 m_updateInterval_us;
 
-    static const char* declinationKey;
+    static const char *s_declinationKey;
 };
 
 #endif // DECLINATIONFILTER_H

--- a/qt-api/abstractsensor_i.cpp
+++ b/qt-api/abstractsensor_i.cpp
@@ -44,7 +44,7 @@ struct AbstractSensorChannelInterface::AbstractSensorChannelInterfaceImpl : publ
     QString m_errorString;
     int m_sessionId;
     int m_interval_us;
-    unsigned int m_bufferInterval;
+    unsigned int m_bufferInterval_ms;
     unsigned int m_bufferSize;
     SocketReader m_socketReader;
     bool m_running;
@@ -58,7 +58,7 @@ AbstractSensorChannelInterface::AbstractSensorChannelInterfaceImpl::AbstractSens
     m_errorString(""),
     m_sessionId(sessionId),
     m_interval_us(0),
-    m_bufferInterval(0),
+    m_bufferInterval_ms(0),
     m_bufferSize(1),
     m_socketReader(parent),
     m_running(false),
@@ -148,7 +148,7 @@ QDBusReply<void> AbstractSensorChannelInterface::start(int sessionId)
 
     setStandbyOverride(sessionId, pimpl_->m_standbyOverride);
     setDataRate(sessionId, dataRate());
-    setBufferInterval(sessionId, pimpl_->m_bufferInterval);
+    setBufferInterval(sessionId, pimpl_->m_bufferInterval_ms);
     setBufferSize(sessionId, pimpl_->m_bufferSize);
     setDownsampling(pimpl_->m_sessionId, pimpl_->m_downsampling);
 
@@ -397,7 +397,7 @@ int AbstractSensorChannelInterface::interval()
         return static_cast<int>(getAccessor<unsigned int>("interval"));
     int interval_ms = 0;
     if (pimpl_->m_interval_us > 0)
-        interval_ms = pimpl_->m_interval_us / 1000;
+        interval_ms = (pimpl_->m_interval_us + 999) / 1000;
     return interval_ms;
 }
 
@@ -433,12 +433,12 @@ unsigned int AbstractSensorChannelInterface::bufferInterval()
 {
     if (pimpl_->m_running)
         return getAccessor<unsigned int>("bufferInterval");
-    return pimpl_->m_bufferInterval;
+    return pimpl_->m_bufferInterval_ms;
 }
 
 void AbstractSensorChannelInterface::setBufferInterval(unsigned int interval_ms)
 {
-    pimpl_->m_bufferInterval = interval_ms;
+    pimpl_->m_bufferInterval_ms = interval_ms;
     if (pimpl_->m_running)
         setBufferInterval(pimpl_->m_sessionId, interval_ms);
 }

--- a/qt-api/abstractsensor_i.h
+++ b/qt-api/abstractsensor_i.h
@@ -123,9 +123,9 @@ public:
      * Value "0" will clear previously set interval.
      * Supported intervals are listed by #getAvailableIntervals().
      *
-     * @param value sampling interval (in millisecs).
+     * @param interval_ms sampling interval (in millisecs).
      */
-    void setInterval(int value);
+    void setInterval(int interval_ms);
 
     /**
      * Is standby-override enabled or not.
@@ -159,9 +159,9 @@ public:
      * buffered data to be flushed unless the buffer is filled before it.
      * Supported intervals are listed by #getAvailableBufferIntervals().
      *
-     * @param value interval in millisecs.
+     * @param interval_ms interval in millisecs.
      */
-    void setBufferInterval(unsigned int value);
+    void setBufferInterval(unsigned int interval_ms);
 
     /**
      * Is downsampling enabled or not.
@@ -324,7 +324,7 @@ private Q_SLOTS: // METHODS
      * @param value interval.
      * @return DBus reply.
      */
-    QDBusReply<void> setInterval(int sessionId, int value);
+    QDBusReply<void> setInterval(int sessionId, int interval_ms);
 
     /**
      * Set standby-override to session.
@@ -342,7 +342,7 @@ private Q_SLOTS: // METHODS
      * @param value buffer interval.
      * @return DBus reply.
      */
-    QDBusReply<void> setBufferInterval(int sessionId, unsigned int value);
+    QDBusReply<void> setBufferInterval(int sessionId, unsigned int interval_ms);
 
     /**
      * Set buffer size to session.

--- a/qt-api/abstractsensor_i.h
+++ b/qt-api/abstractsensor_i.h
@@ -128,6 +128,14 @@ public:
      * @param interval_ms sampling interval (in millisecs).
      */
     void setInterval(int interval_ms);
+
+    /**
+     * Set sensor sampling frequency (in Hertz).
+     * Value "0" will clear previously set interval.
+     * Supported intervals are listed by #getAvailableIntervals().
+     *
+     * @param dataRate_Hz sampling frequency (in Hertz).
+     */
     void setDataRate(double dataRate_Hz);
 
     /**
@@ -324,10 +332,18 @@ private Q_SLOTS: // METHODS
      * Set interval to session.
      *
      * @param sessionId session ID.
-     * @param value interval.
+     * @param interval_ms interval.
      * @return DBus reply.
      */
     QDBusReply<void> setInterval(int sessionId, int interval_ms);
+
+    /**
+     * Set frequency to session.
+     *
+     * @param sessionId session ID.
+     * @param dataRate_Hz frequency
+     * @return DBus reply.
+     */
     QDBusReply<void> setDataRate(int sessionId, double dataRate_Hz);
 
     /**

--- a/qt-api/abstractsensor_i.h
+++ b/qt-api/abstractsensor_i.h
@@ -51,6 +51,7 @@ class AbstractSensorChannelInterface : public QObject
     Q_PROPERTY(QString errorString READ errorString)
     Q_PROPERTY(QString description READ description)
     Q_PROPERTY(QString id READ id)
+    Q_PROPERTY(int dataRate READ dataRate WRITE setDataRate)
     Q_PROPERTY(int interval READ interval WRITE setInterval)
     Q_PROPERTY(bool standbyOverride READ standbyOverride WRITE setStandbyOverride)
     Q_PROPERTY(QString type READ type)
@@ -117,6 +118,7 @@ public:
      * @return used sampling interval (in millisecs)
      */
     int interval();
+    double dataRate();
 
     /**
      * Set sensor sampling interval (in millisecs).
@@ -126,6 +128,7 @@ public:
      * @param interval_ms sampling interval (in millisecs).
      */
     void setInterval(int interval_ms);
+    void setDataRate(double dataRate_Hz);
 
     /**
      * Is standby-override enabled or not.
@@ -325,6 +328,7 @@ private Q_SLOTS: // METHODS
      * @return DBus reply.
      */
     QDBusReply<void> setInterval(int sessionId, int interval_ms);
+    QDBusReply<void> setDataRate(int sessionId, double dataRate_Hz);
 
     /**
      * Set standby-override to session.
@@ -472,6 +476,7 @@ protected slots:
     void stopFinished(QDBusPendingCallWatcher *watch);
 
     void setIntervalFinished(QDBusPendingCallWatcher *watch);
+    void setDataRateFinished(QDBusPendingCallWatcher *watch);
     void setBufferIntervalFinished(QDBusPendingCallWatcher *watch);
     void setBufferSizeFinished(QDBusPendingCallWatcher *watch);
     void setStandbyOverrideFinished(QDBusPendingCallWatcher *watch);

--- a/sensors/contextplugin/orientationbin.cpp
+++ b/sensors/contextplugin/orientationbin.cpp
@@ -101,8 +101,9 @@ void OrientationBin::startRun()
     start();
     orientationChain->start();
 
-    unsigned int pollInterval = SensorFrameworkConfig::configuration()->value("context/orientation_poll_interval", QVariant(POLL_INTERVAL)).toUInt();
-    orientationChain->setIntervalRequest(sessionId, pollInterval);
+    unsigned int pollInterval_ms = SensorFrameworkConfig::configuration()->value("context/orientation_poll_interval", QVariant(POLL_INTERVAL)).toUInt();
+    unsigned int pollInterval_us = pollInterval_ms * 1000;
+    orientationChain->setIntervalRequest(sessionId, pollInterval_us);
 }
 
 void OrientationBin::stopRun()

--- a/sensors/rotationsensor/rotationsensor.cpp
+++ b/sensors/rotationsensor/rotationsensor.cpp
@@ -183,7 +183,7 @@ unsigned int RotationSensorChannel::interval() const
     return accelerometerChain_->getInterval();
 }
 
-bool RotationSensorChannel::setInterval(unsigned int value, int sessionId)
+bool RotationSensorChannel::setInterval(int sessionId, unsigned int value)
 {
     bool success = accelerometerChain_->setIntervalRequest(sessionId, value);
     if (hasZ())

--- a/sensors/rotationsensor/rotationsensor.cpp
+++ b/sensors/rotationsensor/rotationsensor.cpp
@@ -183,12 +183,12 @@ unsigned int RotationSensorChannel::interval() const
     return accelerometerChain_->getInterval();
 }
 
-bool RotationSensorChannel::setInterval(int sessionId, unsigned int value)
+bool RotationSensorChannel::setInterval(int sessionId, unsigned int interval_ms)
 {
-    bool success = accelerometerChain_->setIntervalRequest(sessionId, value);
+    bool success = accelerometerChain_->setIntervalRequest(sessionId, interval_ms);
     if (hasZ())
     {
-        success = compassChain_->setIntervalRequest(sessionId, value) && success;
+        success = compassChain_->setIntervalRequest(sessionId, interval_ms) && success;
     }
 
     return success;

--- a/sensors/rotationsensor/rotationsensor.cpp
+++ b/sensors/rotationsensor/rotationsensor.cpp
@@ -100,16 +100,19 @@ RotationSensorChannel::RotationSensorChannel(const QString& id) :
     if (hasZ())
     {
         // No less than 5hz allowed for compass
-        int ranges[] = {10, 20, 25, 40, 50, 100, 200};
-        for(size_t i = 0; i < sizeof(ranges) / sizeof(int); ++i)
+        int ranges_ms[] = {10, 20, 25, 40, 50, 100, 200};
+        for(size_t i = 0; i < sizeof(ranges_ms) / sizeof(int); ++i)
         {
-            introduceAvailableInterval(DataRange(ranges[i], ranges[i], 0));
+            int range_us = ranges_ms[i] * 1000;
+            introduceAvailableInterval(DataRange(range_us, range_us, 0));
         }
     } else {
         setIntervalSource(accelerometerChain_);
     }
 
-    setDefaultInterval(100); // Tricky. Might need to make this conditional.
+    // Tricky. Might need to make this conditional.
+    unsigned int interval_us = 100 * 1000;
+    setDefaultInterval(interval_us);
 }
 
 RotationSensorChannel::~RotationSensorChannel()
@@ -183,12 +186,12 @@ unsigned int RotationSensorChannel::interval() const
     return accelerometerChain_->getInterval();
 }
 
-bool RotationSensorChannel::setInterval(int sessionId, unsigned int interval_ms)
+bool RotationSensorChannel::setInterval(int sessionId, unsigned int interval_us)
 {
-    bool success = accelerometerChain_->setIntervalRequest(sessionId, interval_ms);
+    bool success = accelerometerChain_->setIntervalRequest(sessionId, interval_us);
     if (hasZ())
     {
-        success = compassChain_->setIntervalRequest(sessionId, interval_ms) && success;
+        success = compassChain_->setIntervalRequest(sessionId, interval_us) && success;
     }
 
     return success;

--- a/sensors/rotationsensor/rotationsensor.h
+++ b/sensors/rotationsensor/rotationsensor.h
@@ -73,7 +73,7 @@ public:
     }
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(int sessionId, unsigned int value);
+    virtual bool setInterval(int sessionId, unsigned int interval_ms);
 
     virtual void removeSession(int sessionId);
 

--- a/sensors/rotationsensor/rotationsensor.h
+++ b/sensors/rotationsensor/rotationsensor.h
@@ -73,7 +73,7 @@ public:
     }
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(int sessionId, unsigned int interval_ms);
+    virtual bool setInterval(int sessionId, unsigned int interval_us);
 
     virtual void removeSession(int sessionId);
 

--- a/sensors/rotationsensor/rotationsensor.h
+++ b/sensors/rotationsensor/rotationsensor.h
@@ -73,7 +73,7 @@ public:
     }
 
     virtual unsigned int interval() const;
-    virtual bool setInterval(unsigned int value, int sessionId);
+    virtual bool setInterval(int sessionId, unsigned int value);
 
     virtual void removeSession(int sessionId);
 

--- a/tests/benchmark/fakeadaptor/fakeadaptor.h
+++ b/tests/benchmark/fakeadaptor/fakeadaptor.h
@@ -43,7 +43,7 @@ public:
     bool running;
 
 private:
-    FakeAdaptor *parent_;
+    FakeAdaptor *m_parent;
 };
 
 /**
@@ -68,14 +68,14 @@ public:
 
     void init();
 
-    unsigned int interval_;
+    unsigned int m_interval_ms;
 
 protected:
     FakeAdaptor(const QString& id);
 
 private:
-    FakeAdaptorThread* t;
-    DeviceAdaptorRingBuffer<TimedUnsigned>* buffer_;
+    FakeAdaptorThread *m_thread;
+    DeviceAdaptorRingBuffer<TimedUnsigned> *m_buffer;
 };
 
 #endif

--- a/tests/benchmark/fakeadaptor/fakeadaptor.h
+++ b/tests/benchmark/fakeadaptor/fakeadaptor.h
@@ -68,7 +68,7 @@ public:
 
     void init();
 
-    unsigned int m_interval_ms;
+    unsigned int m_interval_us;
 
 protected:
     FakeAdaptor(const QString& id);

--- a/tests/testapp/abstractsensorhandler.cpp
+++ b/tests/testapp/abstractsensorhandler.cpp
@@ -29,22 +29,22 @@
 
 AbstractSensorHandler::AbstractSensorHandler(const QString& sensorName, QObject *parent) :
     QThread(parent),
-    sensorName_(sensorName),
-    interval_(100),
-    bufferinterval_(0),
-    standbyoverride_(false),
-    buffersize_(0),
-    dataCount_(0),
-    frameCount_(0),
-    downsample_(false)
+    m_sensorName(sensorName),
+    m_interval_ms(100),
+    m_bufferinterval_ms(0),
+    m_standbyoverride(false),
+    m_buffersize(0),
+    m_dataCount(0),
+    m_frameCount(0),
+    m_downsample(false)
 {
     if (SensorFrameworkConfig::configuration() != NULL)
     {
-        interval_ = SensorFrameworkConfig::configuration()->value(sensorName_ + "/interval", 100);
-        bufferinterval_ = SensorFrameworkConfig::configuration()->value(sensorName_ + "/bufferinterval", 0);
-        standbyoverride_ = SensorFrameworkConfig::configuration()->value(sensorName_ + "/standbyoverride", false);
-        buffersize_ = SensorFrameworkConfig::configuration()->value(sensorName_ + "/buffersize", 0);
-        downsample_ = SensorFrameworkConfig::configuration()->value(sensorName_ + "/downsample", false);
+        m_interval_ms = SensorFrameworkConfig::configuration()->value(m_sensorName + "/interval", 100);
+        m_bufferinterval_ms = SensorFrameworkConfig::configuration()->value(m_sensorName + "/bufferinterval", 0);
+        m_standbyoverride = SensorFrameworkConfig::configuration()->value(m_sensorName + "/standbyoverride", false);
+        m_buffersize = SensorFrameworkConfig::configuration()->value(m_sensorName + "/buffersize", 0);
+        m_downsample = SensorFrameworkConfig::configuration()->value(m_sensorName + "/downsample", false);
     }
 }
 

--- a/tests/testapp/abstractsensorhandler.h
+++ b/tests/testapp/abstractsensorhandler.h
@@ -40,18 +40,18 @@ public:
     virtual bool startClient() = 0;
     virtual bool stopClient() = 0;
 
-    int dataCount() const { return dataCount_; }
-    QString sensorName() const { return sensorName_; }
+    int dataCount() const { return m_dataCount; }
+    QString sensorName() const { return m_sensorName; }
 
 protected:
-    QString sensorName_;
-    int interval_;
-    int bufferinterval_;
-    bool standbyoverride_;
-    int buffersize_;
-    int dataCount_;
-    int frameCount_;
-    bool downsample_;
+    QString m_sensorName;
+    int m_interval_ms;
+    int m_bufferinterval_ms;
+    bool m_standbyoverride;
+    int m_buffersize;
+    int m_dataCount;
+    int m_frameCount;
+    bool m_downsample;
 };
 
 #endif // ABSTRACTSENSORHANDLER_H

--- a/tests/testapp/sensorhandler_qmsystem2.cpp
+++ b/tests/testapp/sensorhandler_qmsystem2.cpp
@@ -27,75 +27,75 @@
 
 SensorHandler::SensorHandler(const QString& sensorName, QObject *parent) :
     AbstractSensorHandler(sensorName, parent),
-    sensor_(NULL)
+    m_sensor(NULL)
 {
-    if (sensorName_ == "compasssensor")
+    if (m_sensorName == "compasssensor")
     {
-        sensor_ = new MeeGo::QmCompass();
-        connect(sensor_, SIGNAL(dataAvailable(const MeeGo::QmCompassReading)), this, SLOT(receivedData(const MeeGo::QmCompassReading)));
+        m_sensor = new MeeGo::QmCompass();
+        connect(m_sensor, SIGNAL(dataAvailable(const MeeGo::QmCompassReading)), this, SLOT(receivedData(const MeeGo::QmCompassReading)));
     }
-    else if (sensorName_ == "magnetometersensor")
+    else if (m_sensorName == "magnetometersensor")
     {
-        sensor_ = new MeeGo::QmMagnetometer();
-        connect(sensor_, SIGNAL(dataAvailable(const MeeGo::QmMagnetometerReading&)), this, SLOT(receivedData(const MeeGo::QmMagnetometerReading&)));
+        m_sensor = new MeeGo::QmMagnetometer();
+        connect(m_sensor, SIGNAL(dataAvailable(const MeeGo::QmMagnetometerReading&)), this, SLOT(receivedData(const MeeGo::QmMagnetometerReading&)));
     }
-    else if (sensorName_ ==  "orientationsensor")
+    else if (m_sensorName ==  "orientationsensor")
     {
-        sensor_ = new MeeGo::QmOrientation();
-        connect(sensor_, SIGNAL(orientationChanged(const MeeGo::QmOrientationReading)), this, SLOT(receivedData(const MeeGo::QmOrientationReading)));
+        m_sensor = new MeeGo::QmOrientation();
+        connect(m_sensor, SIGNAL(orientationChanged(const MeeGo::QmOrientationReading)), this, SLOT(receivedData(const MeeGo::QmOrientationReading)));
     }
-    else if (sensorName_ == "accelerometersensor")
+    else if (m_sensorName == "accelerometersensor")
     {
-        sensor_ = new MeeGo::QmAccelerometer();
-        connect(sensor_, SIGNAL(dataAvailable(const MeeGo::QmAccelerometerReading&)), this, SLOT(receivedData(const MeeGo::QmAccelerometerReading&)));
+        m_sensor = new MeeGo::QmAccelerometer();
+        connect(m_sensor, SIGNAL(dataAvailable(const MeeGo::QmAccelerometerReading&)), this, SLOT(receivedData(const MeeGo::QmAccelerometerReading&)));
     }
-    else if (sensorName_ == "alssensor")
+    else if (m_sensorName == "alssensor")
     {
-        sensor_ = new MeeGo::QmALS();
-        connect(sensor_, SIGNAL(ALSChanged(const MeeGo::QmAlsReading)), this, SLOT(receivedData(const MeeGo::QmIntReading)));
+        m_sensor = new MeeGo::QmALS();
+        connect(m_sensor, SIGNAL(ALSChanged(const MeeGo::QmAlsReading)), this, SLOT(receivedData(const MeeGo::QmIntReading)));
     }
-    else if (sensorName_ == "rotationsensor")
+    else if (m_sensorName == "rotationsensor")
     {
-        sensor_ = new MeeGo::QmRotation();
-        connect(sensor_, SIGNAL(dataAvailable(const MeeGo::QmRotationReading&)), this, SLOT(receivedData(const MeeGo::QmRotationReading&)));
+        m_sensor = new MeeGo::QmRotation();
+        connect(m_sensor, SIGNAL(dataAvailable(const MeeGo::QmRotationReading&)), this, SLOT(receivedData(const MeeGo::QmRotationReading&)));
     }
-    else if (sensorName_ == "tapsensor")
+    else if (m_sensorName == "tapsensor")
     {
-        sensor_ = new MeeGo::QmTap();
-        connect(sensor_, SIGNAL(tapped(const MeeGo::QmTapReading)), this, SLOT(receivedData(const MeeGo::QmTapReading)));
+        m_sensor = new MeeGo::QmTap();
+        connect(m_sensor, SIGNAL(tapped(const MeeGo::QmTapReading)), this, SLOT(receivedData(const MeeGo::QmTapReading)));
     }
-    else if (sensorName_ == "proximitysensor")
+    else if (m_sensorName == "proximitysensor")
     {
-        sensor_ = new MeeGo::QmProximity();
-        connect(sensor_, SIGNAL(ProximityChanged(const MeeGo::QmProximityReading)), this, SLOT(receivedData(const MeeGo::QmIntReading)));
+        m_sensor = new MeeGo::QmProximity();
+        connect(m_sensor, SIGNAL(ProximityChanged(const MeeGo::QmProximityReading)), this, SLOT(receivedData(const MeeGo::QmIntReading)));
     }
 }
 
 void SensorHandler::receivedData(const MeeGo::QmAccelerometerReading& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.x << " " << data.y << " " <<   data.z;
 }
 
 void SensorHandler::receivedData(const MeeGo::QmIntReading data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.value;
 }
 
 void SensorHandler::receivedData(const MeeGo::QmCompassReading data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.level << " " << data.degrees;
 }
 
 void SensorHandler::receivedData(const MeeGo::QmMagnetometerReading& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.x << " " << data.y << " " << data.z << " "
                   << data.rx << " " << data.ry << " " << data.rz << " "
                   << data.level;
@@ -103,30 +103,30 @@ void SensorHandler::receivedData(const MeeGo::QmMagnetometerReading& data)
 
 void SensorHandler::receivedData(const MeeGo::QmOrientationReading data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.value;
 }
 
 void SensorHandler::receivedData(const MeeGo::QmRotationReading& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.x << " " << data.y << " " <<   data.z;
 }
 
 void SensorHandler::receivedData(const MeeGo::QmTapReading data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.type << " " << data.direction;
 }
 
 bool SensorHandler::startClient()
 {
-    sensor_->requestSession(MeeGo::QmSensor::SessionTypeListen);
-    sensor_->setInterval(interval_);
-    sensor_->setStandbyOverride(standbyoverride_);
+    m_sensor->requestSession(MeeGo::QmSensor::SessionTypeListen);
+    m_sensor->setInterval(m_interval_ms);
+    m_sensor->setStandbyOverride(m_standbyoverride);
     return true;
 }
 

--- a/tests/testapp/sensorhandler_qmsystem2.h
+++ b/tests/testapp/sensorhandler_qmsystem2.h
@@ -62,7 +62,7 @@ public Q_SLOTS:
     void receivedData(const MeeGo::QmTapReading data);
 
 private:
-    MeeGo::QmSensor* sensor_;
+    MeeGo::QmSensor *m_sensor;
 };
 
 #endif // SENSORHANDLER_H

--- a/tests/testapp/sensorhandler_qtapi.cpp
+++ b/tests/testapp/sensorhandler_qtapi.cpp
@@ -29,102 +29,102 @@
 
 SensorHandler::SensorHandler(const QString& sensorName, QObject *parent) :
     AbstractSensorHandler(sensorName, parent),
-    sensorChannelInterface_(NULL)
+    m_sensorChannelInterface(NULL)
 {
 }
 
 void SensorHandler::receivedData(const MagneticField& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.x() << " " << data.y() << " " <<   data.z();
 }
 
 void SensorHandler::receivedData(const XYZ& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.x() << " " << data.y() << " " <<   data.z();
 }
 
 void SensorHandler::receivedData(const Compass& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.degrees() << " " << data.level();
 }
 
 void SensorHandler::receivedData(const Unsigned& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.x();
 }
 
 void SensorHandler::receivedData(const Tap& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.direction() << " " << data.type();
 }
 
 void SensorHandler::receivedData(const Proximity& data)
 {
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << data.UnsignedData().value_ << " " << data.proximityData().value_;
 }
 
 void SensorHandler::receivedFrame(const QVector<MagneticField>& frame)
 {
-    ++frameCount_;
-    sensordLogT() << sensorName_ << " frame " << frameCount_ << " size " << frame.size();
+    ++m_frameCount;
+    sensordLogT() << m_sensorName << " frame " << m_frameCount << " size " << frame.size();
     foreach (const MagneticField& data, frame)
     {
         sensordLogT() << data.x() << " " << data.y() << " " << data.z();
-        ++dataCount_;
+        ++m_dataCount;
     }
 }
 
 void SensorHandler::receivedFrame(const QVector<XYZ>& frame)
 {
-    ++frameCount_;
-    sensordLogT() << sensorName_ << " frame " << frameCount_ << " size " << frame.size();
+    ++m_frameCount;
+    sensordLogT() << m_sensorName << " frame " << m_frameCount << " size " << frame.size();
     foreach (const XYZ& data, frame)
     {
         sensordLogT() << data.x() << " " << data.y() << " " << data.z();
-        ++dataCount_;
+        ++m_dataCount;
     }
 }
 
 bool SensorHandler::startClient()
 {
     createSensorInterface();
-    if (sensorChannelInterface_ == 0)
+    if (m_sensorChannelInterface == 0)
     {
          sensordLogD() << "Creating sensor client interface fails.";
          return false;
     }
-    sensordLogD() << "Created sensor: " << sensorChannelInterface_->description();
-    sensordLogD() << "Support intervals: " << toString(sensorChannelInterface_->getAvailableIntervals());
-    sensordLogD() << "Support dataranges: " << toString(sensorChannelInterface_->getAvailableDataRanges());
-    sensorChannelInterface_->setInterval(interval_);
-    sensorChannelInterface_->setBufferInterval(bufferinterval_);
-    sensorChannelInterface_->setBufferSize(buffersize_);
-    sensorChannelInterface_->setStandbyOverride(standbyoverride_);
-    sensorChannelInterface_->setDownsampling(downsample_);
-    sensorChannelInterface_->start();
+    sensordLogD() << "Created sensor: " << m_sensorChannelInterface->description();
+    sensordLogD() << "Support intervals: " << toString(m_sensorChannelInterface->getAvailableIntervals());
+    sensordLogD() << "Support dataranges: " << toString(m_sensorChannelInterface->getAvailableDataRanges());
+    m_sensorChannelInterface->setInterval(m_interval_ms);
+    m_sensorChannelInterface->setBufferInterval(m_bufferinterval_ms);
+    m_sensorChannelInterface->setBufferSize(m_buffersize);
+    m_sensorChannelInterface->setStandbyOverride(m_standbyoverride);
+    m_sensorChannelInterface->setDownsampling(m_downsample);
+    m_sensorChannelInterface->start();
 
     return true;
 }
 
 bool SensorHandler::stopClient()
 {
-    if (sensorChannelInterface_)
+    if (m_sensorChannelInterface)
     {
-        sensorChannelInterface_->stop();
-        delete sensorChannelInterface_;
-        sensorChannelInterface_ = 0;
+        m_sensorChannelInterface->stop();
+        delete m_sensorChannelInterface;
+        m_sensorChannelInterface = 0;
     }
     return true;
 }
@@ -169,48 +169,48 @@ bool SensorHandler::init(const QStringList& sensors)
 
 void SensorHandler::createSensorInterface()
 {
-    if (sensorName_ == "compasssensor")
+    if (m_sensorName == "compasssensor")
     {
-        sensorChannelInterface_ = CompassSensorChannelInterface::interface("compasssensor");
-        connect(sensorChannelInterface_, SIGNAL(dataAvailable(const Compass&)), this, SLOT(receivedData(const Compass&)));
+        m_sensorChannelInterface = CompassSensorChannelInterface::interface("compasssensor");
+        connect(m_sensorChannelInterface, SIGNAL(dataAvailable(const Compass&)), this, SLOT(receivedData(const Compass&)));
     }
-    else if (sensorName_ == "magnetometersensor")
+    else if (m_sensorName == "magnetometersensor")
     {
-        sensorChannelInterface_ = MagnetometerSensorChannelInterface::interface("magnetometersensor");
-        connect(sensorChannelInterface_, SIGNAL(dataAvailable(const MagneticField&)), this, SLOT(receivedData(const MagneticField&)));
-        connect(sensorChannelInterface_, SIGNAL(frameAvailable(const QVector<MagneticField>&)), this, SLOT(receivedFrame(const QVector<MagneticField>&)));
+        m_sensorChannelInterface = MagnetometerSensorChannelInterface::interface("magnetometersensor");
+        connect(m_sensorChannelInterface, SIGNAL(dataAvailable(const MagneticField&)), this, SLOT(receivedData(const MagneticField&)));
+        connect(m_sensorChannelInterface, SIGNAL(frameAvailable(const QVector<MagneticField>&)), this, SLOT(receivedFrame(const QVector<MagneticField>&)));
     }
-    else if (sensorName_ ==  "orientationsensor")
+    else if (m_sensorName ==  "orientationsensor")
     {
-        sensorChannelInterface_ = OrientationSensorChannelInterface::interface("orientationsensor");
-        connect(sensorChannelInterface_, SIGNAL(orientationChanged(const Unsigned&)), this, SLOT(receivedData(const Unsigned&)));
+        m_sensorChannelInterface = OrientationSensorChannelInterface::interface("orientationsensor");
+        connect(m_sensorChannelInterface, SIGNAL(orientationChanged(const Unsigned&)), this, SLOT(receivedData(const Unsigned&)));
     }
-    else if (sensorName_ == "accelerometersensor")
+    else if (m_sensorName == "accelerometersensor")
     {
-        sensorChannelInterface_ = AccelerometerSensorChannelInterface::interface("accelerometersensor");
-        connect(sensorChannelInterface_, SIGNAL(dataAvailable(const XYZ&)), this, SLOT(receivedData(const XYZ&)));
-        connect(sensorChannelInterface_, SIGNAL(frameAvailable(const QVector<XYZ>&)), this, SLOT(receivedFrame(const QVector<XYZ>&)));
+        m_sensorChannelInterface = AccelerometerSensorChannelInterface::interface("accelerometersensor");
+        connect(m_sensorChannelInterface, SIGNAL(dataAvailable(const XYZ&)), this, SLOT(receivedData(const XYZ&)));
+        connect(m_sensorChannelInterface, SIGNAL(frameAvailable(const QVector<XYZ>&)), this, SLOT(receivedFrame(const QVector<XYZ>&)));
     }
-    else if (sensorName_ == "alssensor")
+    else if (m_sensorName == "alssensor")
     {
-        sensorChannelInterface_ = ALSSensorChannelInterface::interface("alssensor");
-        connect(sensorChannelInterface_, SIGNAL(ALSChanged(const Unsigned&)), this, SLOT(receivedData(const Unsigned&)));
+        m_sensorChannelInterface = ALSSensorChannelInterface::interface("alssensor");
+        connect(m_sensorChannelInterface, SIGNAL(ALSChanged(const Unsigned&)), this, SLOT(receivedData(const Unsigned&)));
     }
-    else if (sensorName_ == "rotationsensor")
+    else if (m_sensorName == "rotationsensor")
     {
-        sensorChannelInterface_ = RotationSensorChannelInterface::interface("rotationsensor");
-        connect(sensorChannelInterface_, SIGNAL(dataAvailable(const XYZ&)), this, SLOT(receivedData(const XYZ&)));
-        connect(sensorChannelInterface_, SIGNAL(frameAvailable(const QVector<XYZ>&)), this, SLOT(receivedFrame(const QVector<XYZ>&)));
+        m_sensorChannelInterface = RotationSensorChannelInterface::interface("rotationsensor");
+        connect(m_sensorChannelInterface, SIGNAL(dataAvailable(const XYZ&)), this, SLOT(receivedData(const XYZ&)));
+        connect(m_sensorChannelInterface, SIGNAL(frameAvailable(const QVector<XYZ>&)), this, SLOT(receivedFrame(const QVector<XYZ>&)));
     }
-    else if (sensorName_ == "tapsensor")
+    else if (m_sensorName == "tapsensor")
     {
-        sensorChannelInterface_ = TapSensorChannelInterface::interface("tapsensor");
-        connect(sensorChannelInterface_, SIGNAL(dataAvailable(const Tap&)), this, SLOT(receivedData(const Tap&)));
+        m_sensorChannelInterface = TapSensorChannelInterface::interface("tapsensor");
+        connect(m_sensorChannelInterface, SIGNAL(dataAvailable(const Tap&)), this, SLOT(receivedData(const Tap&)));
     }
-    else if (sensorName_ == "proximitysensor")
+    else if (m_sensorName == "proximitysensor")
     {
-        sensorChannelInterface_ = ProximitySensorChannelInterface::interface("proximitysensor");
-        connect(sensorChannelInterface_, SIGNAL(reflectanceDataAvailable(const Proximity&)), this, SLOT(receivedData(const Proximity&)));
+        m_sensorChannelInterface = ProximitySensorChannelInterface::interface("proximitysensor");
+        connect(m_sensorChannelInterface, SIGNAL(reflectanceDataAvailable(const Proximity&)), this, SLOT(receivedData(const Proximity&)));
     }
 }
 

--- a/tests/testapp/sensorhandler_qtapi.h
+++ b/tests/testapp/sensorhandler_qtapi.h
@@ -70,7 +70,7 @@ private:
 
     static QString toString(const DataRangeList& ranges);
 
-    AbstractSensorChannelInterface* sensorChannelInterface_;
+    AbstractSensorChannelInterface *m_sensorChannelInterface;
 };
 
 #endif // SENSORHANDLER_H

--- a/tests/testapp/sensorhandler_qtmob.cpp
+++ b/tests/testapp/sensorhandler_qtmob.cpp
@@ -30,58 +30,58 @@ SensorHandler::SensorHandler(const QString& sensorName, QObject *parent) :
     AbstractSensorHandler(sensorName, parent),
     m_sensor(NULL)
 {
-    if (sensorName_ == "compasssensor")
+    if (m_sensorName == "compasssensor")
     {
         m_sensor = new QCompass();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedCompassData()));
     }
-    else if (sensorName_ == "magnetometersensor")
+    else if (m_sensorName == "magnetometersensor")
     {
         m_sensor = new QMagnetometer();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedMagnetometerData()));
     }
-    else if (sensorName_ ==  "orientationsensor")
+    else if (m_sensorName ==  "orientationsensor")
     {
         m_sensor = new QOrientationSensor();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedOrientationData()));
     }
-    else if (sensorName_ == "accelerometersensor")
+    else if (m_sensorName == "accelerometersensor")
     {
         m_sensor = new QAccelerometer();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedAccelerometerData()));
     }
-    else if (sensorName_ == "alssensor")
+    else if (m_sensorName == "alssensor")
     {
         m_sensor = new QAmbientLightSensor();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedAlsData()));
     }
-    else if (sensorName_ == "rotationsensor")
+    else if (m_sensorName == "rotationsensor")
     {
         m_sensor = new QRotationSensor();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedRotationData()));
     }
-    else if (sensorName_ == "tapsensor")
+    else if (m_sensorName == "tapsensor")
     {
         m_sensor = new QTapSensor();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedTapData()));
     }
-    else if (sensorName_ == "proximitysensor")
+    else if (m_sensorName == "proximitysensor")
     {
         m_sensor = new QProximitySensor();
         connect(m_sensor, SIGNAL(readingChanged()),
                 this, SLOT(receivedProximityData()));
     }
 
-    m_sensor->setProperty("alwaysOn", standbyoverride_);
-    m_sensor->setProperty("bufferSize", buffersize_);
-    m_sensor->setDataRate(interval_ ? 1000 / interval_ : 0);
+    m_sensor->setProperty("alwaysOn", m_standbyoverride);
+    m_sensor->setProperty("bufferSize", m_buffersize);
+    m_sensor->setDataRate(m_interval_ms ? 1000 / m_interval_ms : 0);
 }
 
 SensorHandler::~SensorHandler()
@@ -92,16 +92,16 @@ SensorHandler::~SensorHandler()
 void SensorHandler::receivedAccelerometerData()
 {
     QAccelerometerReading* data = (QAccelerometerReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << "x " << data->x() << "y " <<  data->y() << "z " <<  data->z();
 }
 
 void SensorHandler::receivedCompassData()
 {
     QCompassReading* data = (QCompassReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
              << " azimuth: " << data->azimuth() << "calibrationLevel: " <<  data-> calibrationLevel();
 
 }
@@ -109,16 +109,16 @@ void SensorHandler::receivedCompassData()
 void SensorHandler::receivedAlsData()
 {
     QAmbientLightReading* data = (QAmbientLightReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << "lightLevel  " << data->lightLevel();
 }
 
 void SensorHandler::receivedMagnetometerData()
 {
     QMagnetometerReading* data = (QMagnetometerReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << "x " << data->x() << "y " <<  data->y() << "z " <<  data->z()
                   << " calibrationLevel" << data->calibrationLevel();
 }
@@ -126,32 +126,32 @@ void SensorHandler::receivedMagnetometerData()
 void SensorHandler::receivedOrientationData()
 {
     QOrientationReading* data = (QOrientationReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << "orientation " << data->orientation();
 }
 
 void SensorHandler::receivedRotationData()
 {
     QRotationReading* data = (QRotationReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << "x " << data->x() << "y " <<  data->y() << "z " <<  data->z();
 }
 
 void SensorHandler::receivedTapData()
 {
     QTapReading* data = (QTapReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << "DoubleTap " <<  data->isDoubleTap();
 }
 
 void SensorHandler::receivedProximityData()
 {
     QProximityReading* data = (QProximityReading*) m_sensor->reading();
-    ++dataCount_;
-    sensordLogT() << sensorName_ << " sample " << dataCount_ << ": "
+    ++m_dataCount;
+    sensordLogT() << m_sensorName << " sample " << m_dataCount << ": "
                   << "Close " <<  data->close();
 }
 


### PR DESCRIPTION
[nodebase] Use closest supported data rate. Fixes JB#60314

What kinds of data rates are available for sensors varies from one
device to another. Having sensorfwd completely ignore out of bounds
data rate requests creates a situation where applications can work in
completely different ways on different devices.

Instead of rejecting out of bounds data requests, choose closest
supported data rate.

[sensorfw] Drop evaluateIntervalRequests overloading. JB#60314

NodeBase::evaluateIntervalRequests is virtual method that about every
derived class overrides - with almost identical copy paste code.

The only difference between these variants is how placeholder zero
interval is handled. Base behavior seems to want to treat it as "as
fast as possible" while others take it to mean "use the defaults."

When intervals were defined in millisecond granularity, using zero
might have had some use for reaching > 1kHz data rates. Now that
microseconds are used, the boundary for expressable data rates has
moved to >1MHz level and dual role for zero value is less useful.

Change NodeBase behavior to match what the multitude of derived
classes used to do and drop all the now unnecessary copy-paste
methods.

[hybrisadaptor] Fix setDelay() return value

If data rate adjustment is skipped because data rate did not change,
setDelay() returns failure - which then causes journal spamming and
other hiccups.

Return success if data rate adjustment is skipped on purpose.

[sensorfw] Handle intervals in microsecond granularity. Fixes JB#60313

Sample intervals within sensorfwd are handled in microsecond granularity
and converted to appropriate units when dealing with external interfaces
such as D-Bus, Android hal, or sysfs control files.

[sensorfw] Add setDataRate() D-Bus method. JB#60417

Using integer millisecond sampling interval is problematic for
specifying high acquisition rates as it limits choice to
1000, 500, 333, 250, 200, ... Hz and thus rules out e.g. 400 Hz
altogether.

Use microsecond granularity interval time internally and provide new
setDataRate() method that takes double precision floating point
Hertz parameter - while retaining the already existing setInterval()
method for the sake of backwards compatibility.

Note that this only deals with D-Bus interface level. Further changes
in sensorfw side are needed to actually support e.g. 400 Hz data rates.

[sensorfw] Explicitly indicate interval time units. JB#60313

As a preparatory step for using different time units in D-Bus interface
and internally within sensorfw: use "_ms" suffix for all interval
arguments and member variables.

Also make affected classes follow m_variableName naming convention.

[sensorfw] Normalize setInterval() parameter order. Fixes JB#60301

The order of interval and session id parameters for setInterval() methods
varies within class hierarchy present in sensorfw.

Normalize situation so that when setInterval() method takes session id
parameter, it is always the first argument to pass - which aligns with
dbus interface.