### PR TITLE
[sensorfwd] Use float values for XYZ data. Fixes JB#60407

### DIFF
--- a/adaptors/mpu6050accelerometer/mpu6050accelerometeradaptor.cpp
+++ b/adaptors/mpu6050accelerometer/mpu6050accelerometeradaptor.cpp
@@ -33,7 +33,7 @@
  * 165.8 is the result of a reference measurement.
  * We are going to correct it such that we get the correct acceleration in m/s^2
  */
-#define CORRECTION_FACTOR (165.8 / EARTH_GRAVITY)
+#define CORRECTION_FACTOR float(165.8 / EARTH_GRAVITY)
 
 Mpu6050AccelAdaptor::Mpu6050AccelAdaptor (const QString& id) :
     SysfsAdaptor (id, SysfsAdaptor::IntervalMode)
@@ -114,13 +114,13 @@ void Mpu6050AccelAdaptor::processSample (int pathId, int fd) {
         case X_AXIS:
             currentData = buffer->nextSlot();                
             currentData->timestamp_ = Utils::getTimeStamp();
-            currentData->x_ = qRound(val / CORRECTION_FACTOR);
+            currentData->x_ = val / CORRECTION_FACTOR;
             break;
         case Y_AXIS:
-            currentData->y_ = qRound(val / CORRECTION_FACTOR);
+            currentData->y_ = val / CORRECTION_FACTOR;
             break;
         case Z_AXIS:
-            currentData->z_ = qRound(val / CORRECTION_FACTOR);
+            currentData->z_ = val / CORRECTION_FACTOR;
             buffer->commit();
             buffer->wakeUpReaders();
             break;

--- a/adaptors/tapadaptor/tapadaptor.cpp
+++ b/adaptors/tapadaptor/tapadaptor.cpp
@@ -96,5 +96,7 @@ void TapAdaptor::commitOutput(const TapData& data)
 
 bool TapAdaptor::setInterval(const int sessionId, const unsigned int interval_us)
 {
+    Q_UNUSED(sessionId);
+    Q_UNUSED(interval_us);
     return true;
 }

--- a/core/abstractsensor.cpp
+++ b/core/abstractsensor.cpp
@@ -137,9 +137,9 @@ bool AbstractSensorChannel::downsampleAndPropagate(const TimedXyzData& data, Tim
         if(samples.size() < bufferSize)
             continue;
 
-        long x = 0;
-        long y = 0;
-        long z = 0;
+        float x = 0;
+        float y = 0;
+        float z = 0;
         foreach(const TimedXyzData& data, samples)
         {
             x += data.x_;

--- a/datatypes/genericdata.h
+++ b/datatypes/genericdata.h
@@ -65,11 +65,11 @@ public:
      * @param y Y coordinate.
      * @param z Z coordinate.
      */
-    TimedXyzData(const quint64& timestamp, int x, int y, int z) : TimedData(timestamp), x_(x), y_(y), z_(z) {}
+    TimedXyzData(const quint64& timestamp, float x, float y, float z) : TimedData(timestamp), x_(x), y_(y), z_(z) {}
 
-    int x_; /**< X value */
-    int y_; /**< Y value */
-    int z_; /**< Z value */
+    float x_; /**< X value */
+    float y_; /**< Y value */
+    float z_; /**< Z value */
 };
 Q_DECLARE_METATYPE ( TimedXyzData )
 

--- a/datatypes/orientation.h
+++ b/datatypes/orientation.h
@@ -90,21 +90,21 @@ public:
      *
      * @return X coordinate.
      */
-    int x() const { return data_.x_; }
+    float x() const { return data_.x_; }
 
     /**
      * Accessor for Y coordinate.
      *
      * @return Y coordinate.
      */
-    int y() const { return data_.y_; }
+    float y() const { return data_.y_; }
 
     /**
      * Accessor for Z coordinate.
      *
      * @return Z coordinate.
      */
-    int z() const { return data_.z_; }
+    float z() const { return data_.z_; }
 
     /**
      * Accessor for display orientation.
@@ -132,6 +132,7 @@ Q_DECLARE_METATYPE( Orientation )
  */
 inline QDBusArgument &operator<<(QDBusArgument &argument, const Orientation &orientation)
 {
+    // No floats on D-Bus: Implicit float to double conversion
     argument.beginStructure();
     argument << orientation.orientationData().timestamp_ << orientation.orientationData().x_ << orientation.orientationData().y_ << orientation.orientationData().z_;
     argument.endStructure();
@@ -147,8 +148,13 @@ inline QDBusArgument &operator<<(QDBusArgument &argument, const Orientation &ori
  */
 inline const QDBusArgument &operator>>(const QDBusArgument &argument, Orientation &orientation)
 {
+    // No floats on D-Bus: Explicit double to float conversion
     argument.beginStructure();
-    argument >> orientation.data_.timestamp_ >> orientation.data_.x_ >> orientation.data_.y_ >> orientation.data_.z_;
+    double x, y, z;
+    argument >> orientation.data_.timestamp_ >> x >> y >> z;
+    orientation.data_.x_ = float(x);
+    orientation.data_.y_ = float(y);
+    orientation.data_.z_ = float(z);
     argument.endStructure();
     return argument;
 }

--- a/datatypes/xyz.h
+++ b/datatypes/xyz.h
@@ -97,21 +97,6 @@ public:
         return *this;
     }
 
-    /**
-     * Comparison operator.
-     *
-     * @param right Object to compare to.
-     * @return comparison result.
-     */
-    bool operator==(const XYZ& right) const
-    {
-        TimedXyzData rdata = right.XYZData();
-        return (data_.x_ == rdata.x_ &&
-                data_.y_ == rdata.y_ &&
-                data_.z_ == rdata.z_ &&
-                data_.timestamp_ == rdata.timestamp_);
-    }
-
 private:
     TimedXyzData data_; /**< Contained data. */
 

--- a/datatypes/xyz.h
+++ b/datatypes/xyz.h
@@ -27,6 +27,8 @@
 #ifndef XYZ_H
 #define XYZ_H
 
+#include <math.h>
+
 #include <QDBusArgument>
 #include <datatypes/orientationdata.h>
 
@@ -72,19 +74,19 @@ public:
      * Returns the value for X.
      * @return x value.
      */
-    int x() const { return data_.x_; }
+    float x() const { return data_.x_; }
 
     /**
      * Returns the value for Y.
      * @return y value.
      */
-    int y() const { return data_.y_; }
+    float y() const { return data_.y_; }
 
     /**
      * Returns the value for Z.
      * @return z value.
      */
-    int z() const { return data_.z_; }
+    float z() const { return data_.z_; }
 
     /**
      * Assignment operator.
@@ -114,6 +116,7 @@ Q_DECLARE_METATYPE( XYZ )
  */
 inline QDBusArgument &operator<<(QDBusArgument &argument, const XYZ &xyz)
 {
+    // No floats on D-Bus: Implicit float to double conversion
     argument.beginStructure();
     argument << xyz.XYZData().timestamp_ << xyz.XYZData().x_ << xyz.XYZData().y_ << xyz.XYZData().z_;
     argument.endStructure();
@@ -129,8 +132,13 @@ inline QDBusArgument &operator<<(QDBusArgument &argument, const XYZ &xyz)
  */
 inline const QDBusArgument &operator>>(const QDBusArgument &argument, XYZ &xyz)
 {
+    // No floats on D-Bus: Explicit double to float conversion
     argument.beginStructure();
-    argument >> xyz.data_.timestamp_ >> xyz.data_.x_ >> xyz.data_.y_ >> xyz.data_.z_;
+    double x, y, z;
+    argument >> xyz.data_.timestamp_ >> x >> y >> z;
+    xyz.data_.x_ = float(x);
+    xyz.data_.y_ = float(y);
+    xyz.data_.z_ = float(z);
     argument.endStructure();
     return argument;
 }

--- a/filters/downsamplefilter/downsamplefilter.cpp
+++ b/filters/downsamplefilter/downsamplefilter.cpp
@@ -77,9 +77,9 @@ void DownsampleFilter::filter(unsigned, const TimedXyzData* data)
     if(static_cast<unsigned int>(buffer_.size()) < bufferSize_)
         return;
 
-    long x = 0;
-    long y = 0;
-    long z = 0;
+    float x = 0;
+    float y = 0;
+    float z = 0;
     foreach(const TimedXyzData& data, buffer_)
     {
         x += data.x_;

--- a/filters/orientationinterpreter/orientationinterpreter.cpp
+++ b/filters/orientationinterpreter/orientationinterpreter.cpp
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <limits.h>
 
-const float OrientationInterpreter::RADIANS_TO_DEGREES = 180.0/M_PI;
+const double OrientationInterpreter::RADIANS_TO_DEGREES = 180.0/M_PI;
 const int OrientationInterpreter::SAME_AXIS_LIMIT = 5;
 const int OrientationInterpreter::OVERFLOW_MIN = 0;
 const int OrientationInterpreter::OVERFLOW_MAX = INT_MAX;
@@ -94,9 +94,9 @@ void OrientationInterpreter::accDataAvailable(unsigned, const AccelerationData* 
     }
 
     //Calculate average
-    long x = 0;
-    long y = 0;
-    long z = 0;
+    float x = 0;
+    float y = 0;
+    float z = 0;
     foreach (const AccelerationData& sample, dataBuffer)
     {
         x += sample.x_;

--- a/filters/orientationinterpreter/orientationinterpreter.h
+++ b/filters/orientationinterpreter/orientationinterpreter.h
@@ -93,7 +93,7 @@ private:
     int orientationCheck(const AccelerationData&, OrientationMode) const;
     PoseData orientationRotation(const AccelerationData&, OrientationMode, PoseData (OrientationInterpreter::*)(int));
 
-    static const float RADIANS_TO_DEGREES;
+    static const double RADIANS_TO_DEGREES;
     static const int SAME_AXIS_LIMIT;
 
     static const int OVERFLOW_MIN;

--- a/filters/rotationfilter/rotationfilter.cpp
+++ b/filters/rotationfilter/rotationfilter.cpp
@@ -39,7 +39,7 @@ RotationFilter::RotationFilter() :
 
 void RotationFilter::interpret(unsigned, const TimedXyzData* data)
 {
-    const int RADIANS_TO_DEGREES = 180/M_PI;
+    const double RADIANS_TO_DEGREES = 180/M_PI;
 
     rotation_.timestamp_ = data->timestamp_;
 

--- a/tests/client/clientapitest.cpp
+++ b/tests/client/clientapitest.cpp
@@ -38,6 +38,16 @@
 #include "clientapitest.h"
 #include <QSettings>
 
+namespace {
+bool areTheSameSample(const XYZ &sample1, const XYZ &sample2)
+{
+    return sample1.XYZData().timestamp_ == sample2.XYZData().timestamp_
+        && sample1.XYZData().x_ == sample2.XYZData().x_
+        && sample1.XYZData().y_ == sample2.XYZData().y_
+        && sample1.XYZData().z_ == sample2.XYZData().z_;
+}
+}
+
 ClientApiTest::ClientApiTest()
 {
     bufferingSensors.append("magnetometersensor");
@@ -195,7 +205,7 @@ void ClientApiTest::testAccelerometerSensor()
 
     XYZ sample1 = sensorIfc->get();
     XYZ sample2 = qvariant_cast<XYZ>(sensorIfc->property("value"));
-    QVERIFY(sample1 == sample2);
+    QVERIFY(areTheSameSample(sample1, sample2));
 
 }
 
@@ -227,7 +237,7 @@ void ClientApiTest::testGyroscopeSensor()
 
     XYZ sample1 = sensorIfc->get();
     XYZ sample2 = qvariant_cast<XYZ>(sensorIfc->property("value"));
-    QVERIFY(sample1 == sample2);
+    QVERIFY(areTheSameSample(sample1, sample2));
 
     delete sensorIfc;
 }
@@ -259,7 +269,7 @@ void ClientApiTest::testMagnetometerSensor()
     MagneticField sample2 = qvariant_cast<MagneticField>(sensorIfc->property("magneticField"));
     // Background process keeps magnetometer on -- values are changing, and subsequent
     // calls are likely to give different values. This makes thus no sense.
-    // QVERIFY(sample1 == sample2);
+    // QVERIFY(areTheSameSample(sample1, sample2));
 
     // test start
     QDBusReply<void> reply = sensorIfc->start();
@@ -452,7 +462,7 @@ void ClientApiTest::testRotationSensor()
     // Need simulated data to make sensible test ouf of this.
     XYZ sample1 = sensorIfc->rotation();
     XYZ sample2 = qvariant_cast<XYZ>(sensorIfc->property("rotation"));
-    QVERIFY(sample1 == sample2);
+    QVERIFY(areTheSameSample(sample1, sample2));
 
     // test start
     QDBusReply<void> reply = sensorIfc->start();


### PR DESCRIPTION
Accelerometer values have granularity of 1 mG even if underlying
sensors would report values with higher accuracy. This happens
implicitly due to internal to sensorfwd storage using integers
for storing xyz vectors.

Switch from integers to single precision floating point numbers.

Applications that use qtsensors API should work without any changes.

Applications that use sensors with xyz data over custom unix socket
io channel need to be adapted to data type change.