### PR TITLE
[hybrisadaptor] Fix build errors from unresolvable id() calls. JB#60480

### DIFF
--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -194,7 +194,7 @@ HybrisManager::HybrisManager(QObject *parent)
                         (hw_module_t const**)&m_halModule);
     if (err != 0) {
         m_halModule = 0;
-        sensordLogW() << id() << "hw_get_module() failed" <<  strerror(-err);
+        sensordLogW() << "hw_get_module() failed" <<  strerror(-err);
         return ;
     }
 
@@ -202,7 +202,7 @@ HybrisManager::HybrisManager(QObject *parent)
     err = sensors_open(&m_halModule->common, &m_halDevice);
     if (err != 0) {
         m_halDevice = 0;
-        sensordLogW() << id() << "sensors_open() failed:" << strerror(-err);
+        sensordLogW() << "sensors_open() failed:" << strerror(-err);
         return;
     }
 


### PR DESCRIPTION
Adding id() context for logging works only from classes that inherit NodeBase. HybrisManager does not and builds fail. This went unnoticed since the code is in #ifdef block that was not used during development time manual builds.

Remove the offending id() calls.