### PR TITLE
[sensorfwd] Use ms values for getAvailableIntervals() reply. Fixes JB#60583

### DIFF
--- a/core/abstractsensor_a.cpp
+++ b/core/abstractsensor_a.cpp
@@ -161,7 +161,12 @@ void AbstractSensorChannelAdaptor::removeDataRangeRequest(int sessionId)
 
 DataRangeList AbstractSensorChannelAdaptor::getAvailableIntervals()
 {
-    return node()->getAvailableIntervals();
+    // D-Bus interface -> interval is milliseconds
+    DataRangeList ranges_us(node()->getAvailableIntervals());
+    DataRangeList ranges_ms;
+    for (auto it = ranges_us.begin(); it != ranges_us.end(); ++it)
+        ranges_ms.append(DataRange(it->min * 0.001, it->max * 0.001, it->resolution));
+    return ranges_ms;
 }
 
 bool AbstractSensorChannelAdaptor::setDefaultInterval(int sessionId)


### PR DESCRIPTION
Sensorfwd was changed to internally use microsecond resolution intervals. But D-Bus interface was supposed to retain millisecond resolution for backwards compatibility. However getAvailableIntervals() method call was missed and thus not addressed and now microsecond values leak to D-Bus causing problems for clients relying on it.

Convert interval ranges from microseconds to milliseconds before sending them to client over D-Bus.