### PR TITLE
core/core.pro: Assure that libsensordatatypes-qt5.so has already been…

### DIFF
--- a/sensorfw.pro
+++ b/sensorfw.pro
@@ -64,6 +64,8 @@ contains(CONFIG,hybris) {
                adaptors
 } else {
     config_hybris {
+    # Reorder so that adaptors are built after hybris.
+    SUBDIRS -= adaptors
     SUBDIRS += core/hybris.pro \
                adaptors
     }


### PR DESCRIPTION
… built before linking libsensorfw-qt5.so against it.