### PR TITLE
Update com.nokia.SensorService.role.json: Add trustLevel

### DIFF
--- a/LuneOS/sysbus/com.nokia.SensorService.role.json
+++ b/LuneOS/sysbus/com.nokia.SensorService.role.json
@@ -1,6 +1,7 @@
 {
     "exeName":"/usr/sbin/sensorfwd",
     "type": "privileged",
+    "trustLevel": "oem",
     "allowedNames": ["com.nokia.SensorService"],
     "permissions": [
         {


### PR DESCRIPTION
Fixes: Dec 13 12:27:03 qemux86-64 ls-hubd[242]: [] [pmlog] ls-hubd LSHUB_ROLE_FILE {"FILE":"file_parser.cpp","LINE":195} No trust level specified for application in role file (/usr/share/luna-service2/roles.d/com.nokia.SensorService.role.json)