### PR TITLE
sensorfw: Fixes from LuneOS

### DIFF
--- a/common-config.pri
+++ b/common-config.pri
@@ -34,7 +34,7 @@ TARGET = $$TARGET-qt$${QT_MAJOR_VERSION}
 OTHER_FILES += \
     ../../common.pri
 
-contains(CONFIG,hybris) {
+contains(CONFIG,hybris)|contains(CONFIG,luneos) {
     CONFIG += link_pkgconfig
     contains(CONFIG,binder) {
         DEFINES += USE_BINDER=1

--- a/core/hybris.pro
+++ b/core/hybris.pro
@@ -19,7 +19,7 @@ LIBS += -L$$[QT_INSTALL_LIBS] -L../datatypes -lsensordatatypes-qt$${QT_MAJOR_VER
 
 CONFIG += link_pkgconfig
 
-!contains(CONFIG,binder) {
+!contains(CONFIG,binder)&!contains(CONFIG,luneos) {
     LIBS += -lhybris-common
     PKGCONFIG += android-headers libhardware
 }

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -832,7 +832,7 @@ void HybrisManager::processSample(const sensors_event_t& data)
 void HybrisManager::registerAdaptor(HybrisAdaptor *adaptor)
 {
     if (!m_registeredAdaptors.values().contains(adaptor) && adaptor->isValid()) {
-        m_registeredAdaptors.insertMulti(adaptor->m_sensorType, adaptor);
+        m_registeredAdaptors.insert(adaptor->m_sensorType, adaptor);
     }
 }
 

--- a/core/hybrisadaptor.h
+++ b/core/hybrisadaptor.h
@@ -186,7 +186,7 @@ public:
 private:
     // fields
     bool                          m_initialized;
-    QMap <int, HybrisAdaptor *>   m_registeredAdaptors; // type -> obj
+    QMultiMap <int, HybrisAdaptor *>   m_registeredAdaptors; // type -> obj
 
 #ifdef USE_BINDER
     // Binder backend

--- a/sensorfw.pro
+++ b/sensorfw.pro
@@ -7,8 +7,11 @@
 #   qmake CONFIG+=autohybris
 # And pro-file behavioral differences are handled via:
 #   config_hybris { ... }
+#
+# LuneOS builds: Uses build time hybris check and special handling of hybris in core/hybris.pro:
+#   qmake CONFIG+=autohybris CONFIG+=luneos
 
-contains(CONFIG,autohybris) {
+contains(CONFIG,autohybris)|contains(CONFIG,luneos) {
     load(configure)
     qtCompileTest(hybris)
 }


### PR DESCRIPTION
insertMulti has been deprecated as per https://doc.qt.io/qt-6/qmultimap-obsolete.html#insertMulti

Use QMultiMap insert instead.

LuneOS uses a hybrid between autohybris and hybris, add a CONFIG option for LuneOS simply.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>