### PR TITLE
Fixes from LuneOS (simplified)

### DIFF
--- a/common-config.pri
+++ b/common-config.pri
@@ -46,5 +46,10 @@ contains(CONFIG,hybris) {
 
 config_hybris {
     CONFIG += link_pkgconfig
-    PKGCONFIG += android-headers libhardware
+    contains(CONFIG,binder) {
+        DEFINES += USE_BINDER=1
+        PKGCONFIG += libgbinder libglibutil gobject-2.0 glib-2.0
+    } else {
+        PKGCONFIG += android-headers libhardware
+    }
 }

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -832,7 +832,7 @@ void HybrisManager::processSample(const sensors_event_t& data)
 void HybrisManager::registerAdaptor(HybrisAdaptor *adaptor)
 {
     if (!m_registeredAdaptors.values().contains(adaptor) && adaptor->isValid()) {
-        m_registeredAdaptors.insertMulti(adaptor->m_sensorType, adaptor);
+        m_registeredAdaptors.insert(adaptor->m_sensorType, adaptor);
     }
 }
 

--- a/core/hybrisadaptor.h
+++ b/core/hybrisadaptor.h
@@ -186,7 +186,7 @@ public:
 private:
     // fields
     bool                          m_initialized;
-    QMap <int, HybrisAdaptor *>   m_registeredAdaptors; // type -> obj
+    QMultiMap <int, HybrisAdaptor *>   m_registeredAdaptors; // type -> obj
 
 #ifdef USE_BINDER
     // Binder backend


### PR DESCRIPTION
This is a replacement proposal for https://github.com/sailfishos/sensorfw/pull/21 where the build fix for using both autohybris and binder was a bit invasive.