### PR TITLE
Motorola gestures

### DIFF
--- a/adaptors/adaptors.pro
+++ b/adaptors/adaptors.pro
@@ -12,7 +12,10 @@ HYBRIS_SUBDIRS = hybrisaccelerometer \
                  hybrisorientationadaptor \
                  hybrisrotationadaptor \
                  hybrisgeorotationadaptor \
-                 hybrisstepcounteradaptor
+                 hybrisstepcounteradaptor \
+                 hybrischopchopadaptor \
+                 hybriscameragestureadaptor \
+                 hybrisliftgestureadaptor
 
 # split like this as Sailfish only installs hybris plugins
 contains(CONFIG,hybris) {

--- a/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptor.cpp
+++ b/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptor.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <QFile>
+#include <QTextStream>
+
+#include "hybriscameragestureadaptor.h"
+#include "logging.h"
+#include "datatypes/utils.h"
+#include "config.h"
+
+namespace {
+int cameraGestureSensorType()
+{
+    QVariant setting(SensorFrameworkConfig::configuration()->value("cameragesture/sensor_type"));
+    bool ok = false;
+    int sensorType = setting.toInt(&ok);
+    if (!ok)
+        sensorType = 65540;
+    qCInfo(lcSensorFw) << "cameraGestureSensorType:" << sensorType;
+    return sensorType;
+}
+}
+
+HybrisCameraGestureAdaptor::HybrisCameraGestureAdaptor(const QString &id)
+    : HybrisAdaptor(id, cameraGestureSensorType())
+{
+    m_buffer = new DeviceAdaptorRingBuffer<TimedUnsigned>(1);
+    setAdaptedSensor("cameragesture", "CameraGesture sensor events", m_buffer);
+    setDescription("Hybris cameraGesture");
+    m_powerStatePath = SensorFrameworkConfig::configuration()->value("cameragesture/powerstate_path").toByteArray();
+    if (!m_powerStatePath.isEmpty() && !QFile::exists(m_powerStatePath)) {
+        qCWarning(lcSensorFw) << NodeBase::id() << "Path does not exists: " << m_powerStatePath;
+        m_powerStatePath.clear();
+    }
+}
+
+HybrisCameraGestureAdaptor::~HybrisCameraGestureAdaptor()
+{
+    delete m_buffer;
+}
+
+bool HybrisCameraGestureAdaptor::startSensor()
+{
+    if (!(HybrisAdaptor::startSensor()))
+        return false;
+    if (isRunning() && !m_powerStatePath.isEmpty())
+        writeToFile(m_powerStatePath, "1");
+    qCInfo(lcSensorFw) << id() << "HybrisCameraGestureAdaptor start";
+    return true;
+}
+
+void HybrisCameraGestureAdaptor::stopSensor()
+{
+    HybrisAdaptor::stopSensor();
+    if (!isRunning() && !m_powerStatePath.isEmpty())
+        writeToFile(m_powerStatePath, "0");
+    qCInfo(lcSensorFw) << id() << "HybrisCameraGestureAdaptor stop";
+}
+
+void HybrisCameraGestureAdaptor::processSample(const sensors_event_t &data)
+{
+    TimedUnsigned *d = m_buffer->nextSlot();
+    d->timestamp_ = quint64(data.timestamp * 0.001);
+
+#ifdef USE_BINDER
+    d->value_ = unsigned(data.u.scalar);
+#else
+    d->value_ = unsigned(data.data[0]);
+#endif
+
+    qCInfo(lcSensorFw) << id() << "HybrisCameraGestureAdaptor event" << d->timestamp_ << d->value_;
+
+    m_buffer->commit();
+    m_buffer->wakeUpReaders();
+}

--- a/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptor.h
+++ b/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptor.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISCAMERAGESTUREADAPTOR_H
+#define HYBRISCAMERAGESTUREADAPTOR_H
+#include "hybrisadaptor.h"
+
+#include <QString>
+#include <QStringList>
+#include <QTime>
+#include <linux/input.h>
+#include "datatypes/timedunsigned.h"
+#include "deviceadaptorringbuffer.h"
+
+/** Adaptor for hybris cameraGesture sensor.
+ *
+ * Adaptor for cameraGesture sensor. Provides cameraGesture events that can be used
+ * for example for triggering SneakPeek mode. Sensor value of one means
+ * cameraGesture condition was met. Other values should be ignored. Uses hybris
+ * sensor daemon driver interface.
+ */
+class HybrisCameraGestureAdaptor : public HybrisAdaptor
+{
+    Q_OBJECT
+
+public:
+    static DeviceAdaptor *factoryMethod(const QString &id) {
+        return new HybrisCameraGestureAdaptor(id);
+    }
+    HybrisCameraGestureAdaptor(const QString &id);
+    ~HybrisCameraGestureAdaptor();
+
+    bool startSensor();
+    void stopSensor();
+
+protected:
+    void processSample(const sensors_event_t &data);
+
+private:
+    DeviceAdaptorRingBuffer<TimedUnsigned> *m_buffer;
+    QByteArray m_powerStatePath;
+};
+#endif // HYBRISCAMERAGESTUREADAPTOR_H

--- a/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptor.pro
+++ b/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptor.pro
@@ -1,0 +1,13 @@
+TARGET = hybriscameragestureadaptor
+
+HEADERS += hybriscameragestureadaptor.h \
+           hybriscameragestureadaptorplugin.h
+
+SOURCES += hybriscameragestureadaptor.cpp \
+           hybriscameragestureadaptorplugin.cpp
+LIBS += -L../../core -lhybrissensorfw-qt$${QT_MAJOR_VERSION}
+
+include( ../adaptor-config.pri )
+config_hybris {
+    PKGCONFIG += android-headers
+}

--- a/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptorplugin.cpp
+++ b/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptorplugin.cpp
@@ -1,0 +1,30 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "hybriscameragestureadaptorplugin.h"
+#include "hybriscameragestureadaptor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void HybrisCameraGestureAdaptorPlugin::Register(class Loader &l)
+{
+    Q_UNUSED(l);
+    qCDebug(lcSensorFw) << "registering hybriscameragestureadaptor";
+    SensorManager &sm = SensorManager::instance();
+    sm.registerDeviceAdaptor<HybrisCameraGestureAdaptor>("cameragestureadaptor");
+}

--- a/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptorplugin.h
+++ b/adaptors/hybriscameragestureadaptor/hybriscameragestureadaptorplugin.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISCAMERAGESTUREADAPTORPLUGIN_H
+#define HYBRISCAMERAGESTUREADAPTORPLUGIN_H
+
+#include "plugin.h"
+
+class HybrisCameraGestureAdaptorPlugin : public Plugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+
+private:
+    void Register(class Loader &l);
+};
+#endif // HYBRISCAMERAGESTUREADAPTORPLUGIN_H

--- a/adaptors/hybrischopchopadaptor/hybrischopchopadaptor.cpp
+++ b/adaptors/hybrischopchopadaptor/hybrischopchopadaptor.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <QFile>
+#include <QTextStream>
+
+#include "hybrischopchopadaptor.h"
+#include "logging.h"
+#include "datatypes/utils.h"
+#include "config.h"
+
+namespace {
+int chopChopSensorType()
+{
+    QVariant setting(SensorFrameworkConfig::configuration()->value("chopchop/sensor_type"));
+    bool ok = false;
+    int sensorType = setting.toInt(&ok);
+    if (!ok)
+        sensorType = 65546;
+    qCInfo(lcSensorFw) << "chopChopSensorType:" << sensorType;
+    return sensorType;
+}
+}
+
+HybrisChopChopAdaptor::HybrisChopChopAdaptor(const QString &id)
+    : HybrisAdaptor(id, chopChopSensorType())
+{
+    m_buffer = new DeviceAdaptorRingBuffer<TimedUnsigned>(1);
+    setAdaptedSensor("chopchop", "ChopChop sensor events", m_buffer);
+    setDescription("Hybris chopChop");
+    m_powerStatePath = SensorFrameworkConfig::configuration()->value("chopchop/powerstate_path").toByteArray();
+    if (!m_powerStatePath.isEmpty() && !QFile::exists(m_powerStatePath)) {
+        qCWarning(lcSensorFw) << NodeBase::id() << "Path does not exists: " << m_powerStatePath;
+        m_powerStatePath.clear();
+    }
+}
+
+HybrisChopChopAdaptor::~HybrisChopChopAdaptor()
+{
+    delete m_buffer;
+}
+
+bool HybrisChopChopAdaptor::startSensor()
+{
+    if (!(HybrisAdaptor::startSensor()))
+        return false;
+    if (isRunning() && !m_powerStatePath.isEmpty())
+        writeToFile(m_powerStatePath, "1");
+    qCInfo(lcSensorFw) << id() << "HybrisChopChopAdaptor start";
+    return true;
+}
+
+void HybrisChopChopAdaptor::stopSensor()
+{
+    HybrisAdaptor::stopSensor();
+    if (!isRunning() && !m_powerStatePath.isEmpty())
+        writeToFile(m_powerStatePath, "0");
+    qCInfo(lcSensorFw) << id() << "HybrisChopChopAdaptor stop";
+}
+
+void HybrisChopChopAdaptor::processSample(const sensors_event_t &data)
+{
+    TimedUnsigned *d = m_buffer->nextSlot();
+    d->timestamp_ = quint64(data.timestamp * 0.001);
+
+#ifdef USE_BINDER
+    d->value_ = unsigned(data.u.scalar);
+#else
+    d->value_ = unsigned(data.data[0]);
+#endif
+
+    qCInfo(lcSensorFw) << id() << "HybrisChopChopAdaptor event" << d->timestamp_ << d->value_;
+
+    m_buffer->commit();
+    m_buffer->wakeUpReaders();
+}

--- a/adaptors/hybrischopchopadaptor/hybrischopchopadaptor.h
+++ b/adaptors/hybrischopchopadaptor/hybrischopchopadaptor.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISCHOPCHOPADAPTOR_H
+#define HYBRISCHOPCHOPADAPTOR_H
+#include "hybrisadaptor.h"
+
+#include <QString>
+#include <QStringList>
+#include <QTime>
+#include <linux/input.h>
+#include "datatypes/timedunsigned.h"
+#include "deviceadaptorringbuffer.h"
+
+/** Adaptor for hybris chopChop sensor.
+ *
+ * Adaptor for chopChop sensor. Provides chopChop events that can be used
+ * for example for triggering SneakPeek mode. Sensor value of one means
+ * chopChop condition was met. Other values should be ignored. Uses hybris
+ * sensor daemon driver interface.
+ */
+class HybrisChopChopAdaptor : public HybrisAdaptor
+{
+    Q_OBJECT
+
+public:
+    static DeviceAdaptor *factoryMethod(const QString &id) {
+        return new HybrisChopChopAdaptor(id);
+    }
+    HybrisChopChopAdaptor(const QString &id);
+    ~HybrisChopChopAdaptor();
+
+    bool startSensor();
+    void stopSensor();
+
+protected:
+    void processSample(const sensors_event_t &data);
+
+private:
+    DeviceAdaptorRingBuffer<TimedUnsigned> *m_buffer;
+    QByteArray m_powerStatePath;
+};
+#endif // HYBRISCHOPCHOPADAPTOR_H

--- a/adaptors/hybrischopchopadaptor/hybrischopchopadaptor.pro
+++ b/adaptors/hybrischopchopadaptor/hybrischopchopadaptor.pro
@@ -1,0 +1,13 @@
+TARGET = hybrischopchopadaptor
+
+HEADERS += hybrischopchopadaptor.h \
+           hybrischopchopadaptorplugin.h
+
+SOURCES += hybrischopchopadaptor.cpp \
+           hybrischopchopadaptorplugin.cpp
+LIBS += -L../../core -lhybrissensorfw-qt$${QT_MAJOR_VERSION}
+
+include( ../adaptor-config.pri )
+config_hybris {
+    PKGCONFIG += android-headers
+}

--- a/adaptors/hybrischopchopadaptor/hybrischopchopadaptorplugin.cpp
+++ b/adaptors/hybrischopchopadaptor/hybrischopchopadaptorplugin.cpp
@@ -1,0 +1,30 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "hybrischopchopadaptorplugin.h"
+#include "hybrischopchopadaptor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void HybrisChopChopAdaptorPlugin::Register(class Loader &l)
+{
+    Q_UNUSED(l);
+    qCDebug(lcSensorFw) << "registering hybrischopchopadaptor";
+    SensorManager &sm = SensorManager::instance();
+    sm.registerDeviceAdaptor<HybrisChopChopAdaptor>("chopchopadaptor");
+}

--- a/adaptors/hybrischopchopadaptor/hybrischopchopadaptorplugin.h
+++ b/adaptors/hybrischopchopadaptor/hybrischopchopadaptorplugin.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISCHOPCHOPADAPTORPLUGIN_H
+#define HYBRISCHOPCHOPADAPTORPLUGIN_H
+
+#include "plugin.h"
+
+class HybrisChopChopAdaptorPlugin : public Plugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+
+private:
+    void Register(class Loader &l);
+};
+#endif // HYBRISCHOPCHOPADAPTORPLUGIN_H

--- a/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptor.cpp
+++ b/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptor.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <QFile>
+#include <QTextStream>
+
+#include "hybrisliftgestureadaptor.h"
+#include "logging.h"
+#include "datatypes/utils.h"
+#include "config.h"
+
+namespace {
+int liftGestureSensorType()
+{
+    QVariant setting(SensorFrameworkConfig::configuration()->value("liftgesture/sensor_type"));
+    bool ok = false;
+    int sensorType = setting.toInt(&ok);
+    if (!ok)
+        sensorType = 65556;
+    qCInfo(lcSensorFw) << "liftGestureSensorType:" << sensorType;
+    return sensorType;
+}
+}
+
+HybrisLiftGestureAdaptor::HybrisLiftGestureAdaptor(const QString &id)
+    : HybrisAdaptor(id, liftGestureSensorType())
+{
+    m_buffer = new DeviceAdaptorRingBuffer<TimedUnsigned>(1);
+    setAdaptedSensor("liftgesture", "LiftGesture sensor events", m_buffer);
+    setDescription("Hybris liftGesture");
+    m_powerStatePath = SensorFrameworkConfig::configuration()->value("liftgesture/powerstate_path").toByteArray();
+    if (!m_powerStatePath.isEmpty() && !QFile::exists(m_powerStatePath)) {
+        qCWarning(lcSensorFw) << NodeBase::id() << "Path does not exists: " << m_powerStatePath;
+        m_powerStatePath.clear();
+    }
+}
+
+HybrisLiftGestureAdaptor::~HybrisLiftGestureAdaptor()
+{
+    delete m_buffer;
+}
+
+bool HybrisLiftGestureAdaptor::startSensor()
+{
+    if (!(HybrisAdaptor::startSensor()))
+        return false;
+    if (isRunning() && !m_powerStatePath.isEmpty())
+        writeToFile(m_powerStatePath, "1");
+    qCInfo(lcSensorFw) << id() << "HybrisLiftGestureAdaptor start";
+    return true;
+}
+
+void HybrisLiftGestureAdaptor::stopSensor()
+{
+    HybrisAdaptor::stopSensor();
+    if (!isRunning() && !m_powerStatePath.isEmpty())
+        writeToFile(m_powerStatePath, "0");
+    qCInfo(lcSensorFw) << id() << "HybrisLiftGestureAdaptor stop";
+}
+
+void HybrisLiftGestureAdaptor::processSample(const sensors_event_t &data)
+{
+    TimedUnsigned *d = m_buffer->nextSlot();
+    d->timestamp_ = quint64(data.timestamp * 0.001);
+
+#ifdef USE_BINDER
+    d->value_ = unsigned(data.u.scalar);
+#else
+    d->value_ = unsigned(data.data[0]);
+#endif
+
+    qCInfo(lcSensorFw) << id() << "HybrisLiftGestureAdaptor event" << d->timestamp_ << d->value_;
+
+    m_buffer->commit();
+    m_buffer->wakeUpReaders();
+}

--- a/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptor.h
+++ b/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptor.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISLIFTGESTUREADAPTOR_H
+#define HYBRISLIFTGESTUREADAPTOR_H
+#include "hybrisadaptor.h"
+
+#include <QString>
+#include <QStringList>
+#include <QTime>
+#include <linux/input.h>
+#include "datatypes/timedunsigned.h"
+#include "deviceadaptorringbuffer.h"
+
+/** Adaptor for hybris liftGesture sensor.
+ *
+ * Adaptor for liftGesture sensor. Provides liftGesture events that can be used
+ * for example for triggering SneakPeek mode. Sensor value of one means
+ * liftGesture condition was met. Other values should be ignored. Uses hybris
+ * sensor daemon driver interface.
+ */
+class HybrisLiftGestureAdaptor : public HybrisAdaptor
+{
+    Q_OBJECT
+
+public:
+    static DeviceAdaptor *factoryMethod(const QString &id) {
+        return new HybrisLiftGestureAdaptor(id);
+    }
+    HybrisLiftGestureAdaptor(const QString &id);
+    ~HybrisLiftGestureAdaptor();
+
+    bool startSensor();
+    void stopSensor();
+
+protected:
+    void processSample(const sensors_event_t &data);
+
+private:
+    DeviceAdaptorRingBuffer<TimedUnsigned> *m_buffer;
+    QByteArray m_powerStatePath;
+};
+#endif // HYBRISLIFTGESTUREADAPTOR_H

--- a/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptor.pro
+++ b/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptor.pro
@@ -1,0 +1,13 @@
+TARGET = hybrisliftgestureadaptor
+
+HEADERS += hybrisliftgestureadaptor.h \
+           hybrisliftgestureadaptorplugin.h
+
+SOURCES += hybrisliftgestureadaptor.cpp \
+           hybrisliftgestureadaptorplugin.cpp
+LIBS += -L../../core -lhybrissensorfw-qt$${QT_MAJOR_VERSION}
+
+include( ../adaptor-config.pri )
+config_hybris {
+    PKGCONFIG += android-headers
+}

--- a/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptorplugin.cpp
+++ b/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptorplugin.cpp
@@ -1,0 +1,30 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "hybrisliftgestureadaptorplugin.h"
+#include "hybrisliftgestureadaptor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void HybrisLiftGestureAdaptorPlugin::Register(class Loader &l)
+{
+    Q_UNUSED(l);
+    qCDebug(lcSensorFw) << "registering hybrisliftgestureadaptor";
+    SensorManager &sm = SensorManager::instance();
+    sm.registerDeviceAdaptor<HybrisLiftGestureAdaptor>("liftgestureadaptor");
+}

--- a/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptorplugin.h
+++ b/adaptors/hybrisliftgestureadaptor/hybrisliftgestureadaptorplugin.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef HYBRISLIFTGESTUREADAPTORPLUGIN_H
+#define HYBRISLIFTGESTUREADAPTORPLUGIN_H
+
+#include "plugin.h"
+
+class HybrisLiftGestureAdaptorPlugin : public Plugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+
+private:
+    void Register(class Loader &l);
+};
+#endif // HYBRISLIFTGESTUREADAPTORPLUGIN_H

--- a/sensors/cameragesturesensor/cameragestureplugin.cpp
+++ b/sensors/cameragesturesensor/cameragestureplugin.cpp
@@ -1,0 +1,45 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "cameragestureplugin.h"
+#include "cameragesturesensor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void CameraGesturePlugin::Register(class Loader &l)
+{
+    Q_UNUSED(l);
+    qCDebug(lcSensorFw) << "registering cameragesturesensor";
+    SensorManager &sm = SensorManager::instance();
+    sm.registerSensor<CameraGestureSensorChannel>("cameragesturesensor");
+}
+
+void CameraGesturePlugin::Init(class Loader &l)
+{
+    Q_UNUSED(l);
+    SensorManager::instance().requestSensor("cameragesturesensor");
+}
+
+QStringList CameraGesturePlugin::Dependencies()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    return QString("cameragestureadaptor").split(":", Qt::SkipEmptyParts);
+#else
+    return QString("cameragestureadaptor").split(":", QString::SkipEmptyParts);
+#endif
+}

--- a/sensors/cameragesturesensor/cameragestureplugin.h
+++ b/sensors/cameragesturesensor/cameragestureplugin.h
@@ -1,0 +1,34 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CAMERAGESTUREPLUGIN_H
+#define CAMERAGESTUREPLUGIN_H
+
+#include "plugin.h"
+
+class CameraGesturePlugin : public Plugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+
+private:
+    void Register(class Loader &l);
+    void Init(class Loader &l);
+    QStringList Dependencies();
+};
+#endif // CAMERAGESTUREPLUGIN_H

--- a/sensors/cameragesturesensor/cameragesturesensor.cpp
+++ b/sensors/cameragesturesensor/cameragesturesensor.cpp
@@ -1,0 +1,129 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "cameragesturesensor.h"
+
+#include "sensormanager.h"
+#include "bin.h"
+#include "bufferreader.h"
+
+CameraGestureSensorChannel::CameraGestureSensorChannel(const QString &id)
+    : AbstractSensorChannel(id)
+    , DataEmitter<TimedUnsigned>(1)
+    , m_previousValue(0, 0)
+    , m_filterBin(nullptr)
+    , m_marshallingBin(nullptr)
+    , m_cameraGestureAdaptor(nullptr)
+    , m_cameraGestureReader(nullptr)
+    , m_outputBuffer(nullptr)
+{
+    SensorManager &sm = SensorManager::instance();
+
+    m_cameraGestureAdaptor = sm.requestDeviceAdaptor("cameragestureadaptor");
+    if (!m_cameraGestureAdaptor) {
+        setValid(false);
+        return;
+    }
+
+    m_cameraGestureReader = new BufferReader<TimedUnsigned>(1);
+
+    m_outputBuffer = new RingBuffer<TimedUnsigned>(1);
+
+    // Create buffers for filter chain
+    m_filterBin = new Bin;
+
+    m_filterBin->add(m_cameraGestureReader, "cameragesture");
+    m_filterBin->add(m_outputBuffer, "buffer");
+
+    m_filterBin->join("cameragesture", "source", "buffer", "sink");
+
+    // Join datasources to the chain
+    connectToSource(m_cameraGestureAdaptor, "cameragesture", m_cameraGestureReader);
+
+    m_marshallingBin = new Bin;
+    m_marshallingBin->add(this, "sensorchannel");
+
+    m_outputBuffer->join(this);
+
+    setDescription("cameragesture events");
+    setRangeSource(m_cameraGestureAdaptor);
+    addStandbyOverrideSource(m_cameraGestureAdaptor);
+    setIntervalSource(m_cameraGestureAdaptor);
+
+    setValid(true);
+}
+
+CameraGestureSensorChannel::~CameraGestureSensorChannel()
+{
+    if (m_cameraGestureAdaptor) {
+        SensorManager &sm = SensorManager::instance();
+        disconnectFromSource(m_cameraGestureAdaptor, "cameragesture", m_cameraGestureReader);
+        sm.releaseDeviceAdaptor("cameragestureadaptor");
+        m_cameraGestureAdaptor = nullptr;
+    }
+
+    delete m_marshallingBin;
+    m_marshallingBin = nullptr;
+
+    delete m_filterBin;
+    m_filterBin = nullptr;
+
+    delete m_outputBuffer;
+    m_outputBuffer = nullptr;
+
+    delete m_cameraGestureReader;
+    m_cameraGestureReader = nullptr;
+}
+
+bool CameraGestureSensorChannel::start()
+{
+    qCDebug(lcSensorFw) << id() << "Starting CameraGestureSensorChannel";
+
+    if (AbstractSensorChannel::start()) {
+        m_marshallingBin->start();
+        m_filterBin->start();
+        m_cameraGestureAdaptor->startSensor();
+    }
+    return true;
+}
+
+bool CameraGestureSensorChannel::stop()
+{
+    qCDebug(lcSensorFw) << id() << "Stopping CameraGestureSensorChannel";
+
+    if (AbstractSensorChannel::stop()) {
+        m_cameraGestureAdaptor->stopSensor();
+        m_filterBin->stop();
+        m_marshallingBin->stop();
+    }
+    return true;
+}
+
+void CameraGestureSensorChannel::emitData(const TimedUnsigned &value)
+{
+    qCDebug(lcSensorFw) << id()
+        << "old:" << m_previousValue.value_
+        << "-->"
+        << "new:" << value.value_;
+
+    if (value.value_ != m_previousValue.value_) {
+        m_previousValue.value_ = value.value_;
+        //writeToClients((const void *)&value, sizeof value);
+    }
+    writeToClients((const void *)&value, sizeof value);
+}

--- a/sensors/cameragesturesensor/cameragesturesensor.h
+++ b/sensors/cameragesturesensor/cameragesturesensor.h
@@ -1,0 +1,94 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CAMERAGESTURE_SENSOR_CHANNEL_H
+#define CAMERAGESTURE_SENSOR_CHANNEL_H
+
+#include <QObject>
+
+#include "deviceadaptor.h"
+#include "abstractsensor.h"
+#include "cameragesturesensor_a.h"
+#include "dataemitter.h"
+#include "datatypes/timedunsigned.h"
+#include "datatypes/unsigned.h"
+
+class Bin;
+template <class TYPE> class BufferReader;
+class FilterBase;
+
+/** Sensor for accessing cameragesture sensor events.
+ *
+ * Signals whenever cameragesture sensor events are received.
+ */
+class CameraGestureSensorChannel
+    : public AbstractSensorChannel
+    , public DataEmitter<TimedUnsigned>
+{
+    Q_OBJECT
+    Q_PROPERTY(Unsigned cameraGesture READ cameraGesture NOTIFY cameraGestureChanged)
+
+public:
+    /** Factory method for CameraGestureSensorChannel.
+     *
+     * @return New CameraGestureSensorChannel as AbstractSensorChannel*
+     */
+    static AbstractSensorChannel *factoryMethod(const QString &id)
+    {
+        CameraGestureSensorChannel *sc = new CameraGestureSensorChannel(id);
+        new CameraGestureSensorChannelAdaptor(sc);
+
+        return sc;
+    }
+
+    /** Property for accessing the measured value.
+     *
+     * Note that sensor does not have a state and thus
+     * the last measured value is meaningness and is
+     * provided only for the sake of symmetry.
+     *
+     * @return Last measured value.
+     */
+    Unsigned cameraGesture() const { return m_previousValue; }
+
+public Q_SLOTS:
+    bool start();
+    bool stop();
+
+signals:
+    /** Sent when a change in measured data is observed.
+     *
+     * @param value Measured value.
+     */
+    void cameraGestureChanged(const Unsigned &value);
+
+protected:
+    CameraGestureSensorChannel(const QString &id);
+    virtual ~CameraGestureSensorChannel();
+
+private:
+    TimedUnsigned m_previousValue;
+    Bin *m_filterBin;
+    Bin *m_marshallingBin;
+    DeviceAdaptor *m_cameraGestureAdaptor;
+    BufferReader<TimedUnsigned> *m_cameraGestureReader;
+    RingBuffer<TimedUnsigned> *m_outputBuffer;
+
+    void emitData(const TimedUnsigned &value);
+};
+#endif // CAMERAGESTURE_SENSOR_CHANNEL_H

--- a/sensors/cameragesturesensor/cameragesturesensor.pro
+++ b/sensors/cameragesturesensor/cameragesturesensor.pro
@@ -1,0 +1,18 @@
+CONFIG += link_pkgconfig
+
+TARGET = cameragesturesensor
+
+HEADERS += cameragesturesensor.h \
+           cameragesturesensor_a.h \
+           cameragestureplugin.h
+
+SOURCES += cameragesturesensor.cpp \
+           cameragesturesensor_a.cpp \
+           cameragestureplugin.cpp
+
+include( ../sensor-config.pri )
+
+contextprovider {
+    DEFINES += PROVIDE_CONTEXT_INFO
+    PKGCONFIG += contextprovider-1.0
+}

--- a/sensors/cameragesturesensor/cameragesturesensor_a.cpp
+++ b/sensors/cameragesturesensor/cameragesturesensor_a.cpp
@@ -1,0 +1,29 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "cameragesturesensor_a.h"
+
+CameraGestureSensorChannelAdaptor::CameraGestureSensorChannelAdaptor(QObject *parent)
+    : AbstractSensorChannelAdaptor(parent)
+{
+}
+
+Unsigned CameraGestureSensorChannelAdaptor::cameraGesture() const
+{
+    return qvariant_cast<Unsigned>(parent()->property("cameragesture"));
+}

--- a/sensors/cameragesturesensor/cameragesturesensor_a.h
+++ b/sensors/cameragesturesensor/cameragesturesensor_a.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CAMERAGESTURE_SENSOR_H
+#define CAMERAGESTURE_SENSOR_H
+
+#include <QtDBus/QtDBus>
+#include <QObject>
+
+#include "datatypes/unsigned.h"
+#include "abstractsensor_a.h"
+
+class CameraGestureSensorChannelAdaptor : public AbstractSensorChannelAdaptor
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(CameraGestureSensorChannelAdaptor)
+    Q_CLASSINFO("D-Bus Interface", "local.CameraGestureSensor")
+    Q_PROPERTY(Unsigned cameraGesture READ cameraGesture NOTIFY cameraGestureChanged)
+
+public:
+    CameraGestureSensorChannelAdaptor(QObject *parent);
+
+public Q_SLOTS:
+    Unsigned cameraGesture() const;
+
+Q_SIGNALS:
+    void cameraGestureChanged(const Unsigned &value);
+};
+#endif // CAMERAGESTURE_SENSOR_H

--- a/sensors/chopchopsensor/chopchopplugin.cpp
+++ b/sensors/chopchopsensor/chopchopplugin.cpp
@@ -1,0 +1,45 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "chopchopplugin.h"
+#include "chopchopsensor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void ChopChopPlugin::Register(class Loader &l)
+{
+    Q_UNUSED(l);
+    qCDebug(lcSensorFw) << "registering chopchopsensor";
+    SensorManager &sm = SensorManager::instance();
+    sm.registerSensor<ChopChopSensorChannel>("chopchopsensor");
+}
+
+void ChopChopPlugin::Init(class Loader &l)
+{
+    Q_UNUSED(l);
+    SensorManager::instance().requestSensor("chopchopsensor");
+}
+
+QStringList ChopChopPlugin::Dependencies()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    return QString("chopchopadaptor").split(":", Qt::SkipEmptyParts);
+#else
+    return QString("chopchopadaptor").split(":", QString::SkipEmptyParts);
+#endif
+}

--- a/sensors/chopchopsensor/chopchopplugin.h
+++ b/sensors/chopchopsensor/chopchopplugin.h
@@ -1,0 +1,34 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CHOPCHOPPLUGIN_H
+#define CHOPCHOPPLUGIN_H
+
+#include "plugin.h"
+
+class ChopChopPlugin : public Plugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+
+private:
+    void Register(class Loader &l);
+    void Init(class Loader &l);
+    QStringList Dependencies();
+};
+#endif // CHOPCHOPPLUGIN_H

--- a/sensors/chopchopsensor/chopchopsensor.cpp
+++ b/sensors/chopchopsensor/chopchopsensor.cpp
@@ -1,0 +1,129 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "chopchopsensor.h"
+
+#include "sensormanager.h"
+#include "bin.h"
+#include "bufferreader.h"
+
+ChopChopSensorChannel::ChopChopSensorChannel(const QString &id)
+    : AbstractSensorChannel(id)
+    , DataEmitter<TimedUnsigned>(1)
+    , m_previousValue(0, 0)
+    , m_filterBin(nullptr)
+    , m_marshallingBin(nullptr)
+    , m_chopChopAdaptor(nullptr)
+    , m_chopChopReader(nullptr)
+    , m_outputBuffer(nullptr)
+{
+    SensorManager &sm = SensorManager::instance();
+
+    m_chopChopAdaptor = sm.requestDeviceAdaptor("chopchopadaptor");
+    if (!m_chopChopAdaptor) {
+        setValid(false);
+        return;
+    }
+
+    m_chopChopReader = new BufferReader<TimedUnsigned>(1);
+
+    m_outputBuffer = new RingBuffer<TimedUnsigned>(1);
+
+    // Create buffers for filter chain
+    m_filterBin = new Bin;
+
+    m_filterBin->add(m_chopChopReader, "chopchop");
+    m_filterBin->add(m_outputBuffer, "buffer");
+
+    m_filterBin->join("chopchop", "source", "buffer", "sink");
+
+    // Join datasources to the chain
+    connectToSource(m_chopChopAdaptor, "chopchop", m_chopChopReader);
+
+    m_marshallingBin = new Bin;
+    m_marshallingBin->add(this, "sensorchannel");
+
+    m_outputBuffer->join(this);
+
+    setDescription("chopchop events");
+    setRangeSource(m_chopChopAdaptor);
+    addStandbyOverrideSource(m_chopChopAdaptor);
+    setIntervalSource(m_chopChopAdaptor);
+
+    setValid(true);
+}
+
+ChopChopSensorChannel::~ChopChopSensorChannel()
+{
+    if (m_chopChopAdaptor) {
+        SensorManager &sm = SensorManager::instance();
+        disconnectFromSource(m_chopChopAdaptor, "chopchop", m_chopChopReader);
+        sm.releaseDeviceAdaptor("chopchopadaptor");
+        m_chopChopAdaptor = nullptr;
+    }
+
+    delete m_marshallingBin;
+    m_marshallingBin = nullptr;
+
+    delete m_filterBin;
+    m_filterBin = nullptr;
+
+    delete m_outputBuffer;
+    m_outputBuffer = nullptr;
+
+    delete m_chopChopReader;
+    m_chopChopReader = nullptr;
+}
+
+bool ChopChopSensorChannel::start()
+{
+    qCDebug(lcSensorFw) << id() << "Starting ChopChopSensorChannel";
+
+    if (AbstractSensorChannel::start()) {
+        m_marshallingBin->start();
+        m_filterBin->start();
+        m_chopChopAdaptor->startSensor();
+    }
+    return true;
+}
+
+bool ChopChopSensorChannel::stop()
+{
+    qCDebug(lcSensorFw) << id() << "Stopping ChopChopSensorChannel";
+
+    if (AbstractSensorChannel::stop()) {
+        m_chopChopAdaptor->stopSensor();
+        m_filterBin->stop();
+        m_marshallingBin->stop();
+    }
+    return true;
+}
+
+void ChopChopSensorChannel::emitData(const TimedUnsigned &value)
+{
+    qCDebug(lcSensorFw) << id()
+        << "old:" << m_previousValue.value_
+        << "-->"
+        << "new:" << value.value_;
+
+    if (value.value_ != m_previousValue.value_) {
+        m_previousValue.value_ = value.value_;
+        //writeToClients((const void *)&value, sizeof value);
+    }
+    writeToClients((const void *)&value, sizeof value);
+}

--- a/sensors/chopchopsensor/chopchopsensor.h
+++ b/sensors/chopchopsensor/chopchopsensor.h
@@ -1,0 +1,94 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CHOPCHOP_SENSOR_CHANNEL_H
+#define CHOPCHOP_SENSOR_CHANNEL_H
+
+#include <QObject>
+
+#include "deviceadaptor.h"
+#include "abstractsensor.h"
+#include "chopchopsensor_a.h"
+#include "dataemitter.h"
+#include "datatypes/timedunsigned.h"
+#include "datatypes/unsigned.h"
+
+class Bin;
+template <class TYPE> class BufferReader;
+class FilterBase;
+
+/** Sensor for accessing chopchop sensor events.
+ *
+ * Signals whenever chopchop sensor events are received.
+ */
+class ChopChopSensorChannel
+    : public AbstractSensorChannel
+    , public DataEmitter<TimedUnsigned>
+{
+    Q_OBJECT
+    Q_PROPERTY(Unsigned chopChop READ chopChop NOTIFY chopChopChanged)
+
+public:
+    /** Factory method for ChopChopSensorChannel.
+     *
+     * @return New ChopChopSensorChannel as AbstractSensorChannel*
+     */
+    static AbstractSensorChannel *factoryMethod(const QString &id)
+    {
+        ChopChopSensorChannel *sc = new ChopChopSensorChannel(id);
+        new ChopChopSensorChannelAdaptor(sc);
+
+        return sc;
+    }
+
+    /** Property for accessing the measured value.
+     *
+     * Note that sensor does not have a state and thus
+     * the last measured value is meaningness and is
+     * provided only for the sake of symmetry.
+     *
+     * @return Last measured value.
+     */
+    Unsigned chopChop() const { return m_previousValue; }
+
+public Q_SLOTS:
+    bool start();
+    bool stop();
+
+signals:
+    /** Sent when a change in measured data is observed.
+     *
+     * @param value Measured value.
+     */
+    void chopChopChanged(const Unsigned &value);
+
+protected:
+    ChopChopSensorChannel(const QString &id);
+    virtual ~ChopChopSensorChannel();
+
+private:
+    TimedUnsigned m_previousValue;
+    Bin *m_filterBin;
+    Bin *m_marshallingBin;
+    DeviceAdaptor *m_chopChopAdaptor;
+    BufferReader<TimedUnsigned> *m_chopChopReader;
+    RingBuffer<TimedUnsigned> *m_outputBuffer;
+
+    void emitData(const TimedUnsigned &value);
+};
+#endif // CHOPCHOP_SENSOR_CHANNEL_H

--- a/sensors/chopchopsensor/chopchopsensor.pro
+++ b/sensors/chopchopsensor/chopchopsensor.pro
@@ -1,0 +1,18 @@
+CONFIG += link_pkgconfig
+
+TARGET = chopchopsensor
+
+HEADERS += chopchopsensor.h \
+           chopchopsensor_a.h \
+           chopchopplugin.h
+
+SOURCES += chopchopsensor.cpp \
+           chopchopsensor_a.cpp \
+           chopchopplugin.cpp
+
+include( ../sensor-config.pri )
+
+contextprovider {
+    DEFINES += PROVIDE_CONTEXT_INFO
+    PKGCONFIG += contextprovider-1.0
+}

--- a/sensors/chopchopsensor/chopchopsensor_a.cpp
+++ b/sensors/chopchopsensor/chopchopsensor_a.cpp
@@ -1,0 +1,29 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "chopchopsensor_a.h"
+
+ChopChopSensorChannelAdaptor::ChopChopSensorChannelAdaptor(QObject *parent)
+    : AbstractSensorChannelAdaptor(parent)
+{
+}
+
+Unsigned ChopChopSensorChannelAdaptor::chopChop() const
+{
+    return qvariant_cast<Unsigned>(parent()->property("chopchop"));
+}

--- a/sensors/chopchopsensor/chopchopsensor_a.h
+++ b/sensors/chopchopsensor/chopchopsensor_a.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CHOPCHOP_SENSOR_H
+#define CHOPCHOP_SENSOR_H
+
+#include <QtDBus/QtDBus>
+#include <QObject>
+
+#include "datatypes/unsigned.h"
+#include "abstractsensor_a.h"
+
+class ChopChopSensorChannelAdaptor : public AbstractSensorChannelAdaptor
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(ChopChopSensorChannelAdaptor)
+    Q_CLASSINFO("D-Bus Interface", "local.ChopChopSensor")
+    Q_PROPERTY(Unsigned chopChop READ chopChop NOTIFY chopChopChanged)
+
+public:
+    ChopChopSensorChannelAdaptor(QObject *parent);
+
+public Q_SLOTS:
+    Unsigned chopChop() const;
+
+Q_SIGNALS:
+    void chopChopChanged(const Unsigned &value);
+};
+#endif // CHOPCHOP_SENSOR_H

--- a/sensors/liftgesturesensor/liftgestureplugin.cpp
+++ b/sensors/liftgesturesensor/liftgestureplugin.cpp
@@ -1,0 +1,45 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "liftgestureplugin.h"
+#include "liftgesturesensor.h"
+#include "sensormanager.h"
+#include "logging.h"
+
+void LiftGesturePlugin::Register(class Loader &l)
+{
+    Q_UNUSED(l);
+    qCDebug(lcSensorFw) << "registering liftgesturesensor";
+    SensorManager &sm = SensorManager::instance();
+    sm.registerSensor<LiftGestureSensorChannel>("liftgesturesensor");
+}
+
+void LiftGesturePlugin::Init(class Loader &l)
+{
+    Q_UNUSED(l);
+    SensorManager::instance().requestSensor("liftgesturesensor");
+}
+
+QStringList LiftGesturePlugin::Dependencies()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    return QString("liftgestureadaptor").split(":", Qt::SkipEmptyParts);
+#else
+    return QString("liftgestureadaptor").split(":", QString::SkipEmptyParts);
+#endif
+}

--- a/sensors/liftgesturesensor/liftgestureplugin.h
+++ b/sensors/liftgesturesensor/liftgestureplugin.h
@@ -1,0 +1,34 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef LIFTGESTUREPLUGIN_H
+#define LIFTGESTUREPLUGIN_H
+
+#include "plugin.h"
+
+class LiftGesturePlugin : public Plugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.nokia.SensorService.Plugin/1.0")
+
+private:
+    void Register(class Loader &l);
+    void Init(class Loader &l);
+    QStringList Dependencies();
+};
+#endif // LIFTGESTUREPLUGIN_H

--- a/sensors/liftgesturesensor/liftgesturesensor.cpp
+++ b/sensors/liftgesturesensor/liftgesturesensor.cpp
@@ -1,0 +1,129 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "liftgesturesensor.h"
+
+#include "sensormanager.h"
+#include "bin.h"
+#include "bufferreader.h"
+
+LiftGestureSensorChannel::LiftGestureSensorChannel(const QString &id)
+    : AbstractSensorChannel(id)
+    , DataEmitter<TimedUnsigned>(1)
+    , m_previousValue(0, 0)
+    , m_filterBin(nullptr)
+    , m_marshallingBin(nullptr)
+    , m_liftGestureAdaptor(nullptr)
+    , m_liftGestureReader(nullptr)
+    , m_outputBuffer(nullptr)
+{
+    SensorManager &sm = SensorManager::instance();
+
+    m_liftGestureAdaptor = sm.requestDeviceAdaptor("liftgestureadaptor");
+    if (!m_liftGestureAdaptor) {
+        setValid(false);
+        return;
+    }
+
+    m_liftGestureReader = new BufferReader<TimedUnsigned>(1);
+
+    m_outputBuffer = new RingBuffer<TimedUnsigned>(1);
+
+    // Create buffers for filter chain
+    m_filterBin = new Bin;
+
+    m_filterBin->add(m_liftGestureReader, "liftgesture");
+    m_filterBin->add(m_outputBuffer, "buffer");
+
+    m_filterBin->join("liftgesture", "source", "buffer", "sink");
+
+    // Join datasources to the chain
+    connectToSource(m_liftGestureAdaptor, "liftgesture", m_liftGestureReader);
+
+    m_marshallingBin = new Bin;
+    m_marshallingBin->add(this, "sensorchannel");
+
+    m_outputBuffer->join(this);
+
+    setDescription("liftgesture events");
+    setRangeSource(m_liftGestureAdaptor);
+    addStandbyOverrideSource(m_liftGestureAdaptor);
+    setIntervalSource(m_liftGestureAdaptor);
+
+    setValid(true);
+}
+
+LiftGestureSensorChannel::~LiftGestureSensorChannel()
+{
+    if (m_liftGestureAdaptor) {
+        SensorManager &sm = SensorManager::instance();
+        disconnectFromSource(m_liftGestureAdaptor, "liftgesture", m_liftGestureReader);
+        sm.releaseDeviceAdaptor("liftgestureadaptor");
+        m_liftGestureAdaptor = nullptr;
+    }
+
+    delete m_marshallingBin;
+    m_marshallingBin = nullptr;
+
+    delete m_filterBin;
+    m_filterBin = nullptr;
+
+    delete m_outputBuffer;
+    m_outputBuffer = nullptr;
+
+    delete m_liftGestureReader;
+    m_liftGestureReader = nullptr;
+}
+
+bool LiftGestureSensorChannel::start()
+{
+    qCDebug(lcSensorFw) << id() << "Starting LiftGestureSensorChannel";
+
+    if (AbstractSensorChannel::start()) {
+        m_marshallingBin->start();
+        m_filterBin->start();
+        m_liftGestureAdaptor->startSensor();
+    }
+    return true;
+}
+
+bool LiftGestureSensorChannel::stop()
+{
+    qCDebug(lcSensorFw) << id() << "Stopping LiftGestureSensorChannel";
+
+    if (AbstractSensorChannel::stop()) {
+        m_liftGestureAdaptor->stopSensor();
+        m_filterBin->stop();
+        m_marshallingBin->stop();
+    }
+    return true;
+}
+
+void LiftGestureSensorChannel::emitData(const TimedUnsigned &value)
+{
+    qCDebug(lcSensorFw) << id()
+        << "old:" << m_previousValue.value_
+        << "-->"
+        << "new:" << value.value_;
+
+    if (value.value_ != m_previousValue.value_) {
+        m_previousValue.value_ = value.value_;
+        //writeToClients((const void *)&value, sizeof value);
+    }
+    writeToClients((const void *)&value, sizeof value);
+}

--- a/sensors/liftgesturesensor/liftgesturesensor.h
+++ b/sensors/liftgesturesensor/liftgesturesensor.h
@@ -1,0 +1,94 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef LIFTGESTURE_SENSOR_CHANNEL_H
+#define LIFTGESTURE_SENSOR_CHANNEL_H
+
+#include <QObject>
+
+#include "deviceadaptor.h"
+#include "abstractsensor.h"
+#include "liftgesturesensor_a.h"
+#include "dataemitter.h"
+#include "datatypes/timedunsigned.h"
+#include "datatypes/unsigned.h"
+
+class Bin;
+template <class TYPE> class BufferReader;
+class FilterBase;
+
+/** Sensor for accessing liftgesture sensor events.
+ *
+ * Signals whenever liftgesture sensor events are received.
+ */
+class LiftGestureSensorChannel
+    : public AbstractSensorChannel
+    , public DataEmitter<TimedUnsigned>
+{
+    Q_OBJECT
+    Q_PROPERTY(Unsigned liftGesture READ liftGesture NOTIFY liftGestureChanged)
+
+public:
+    /** Factory method for LiftGestureSensorChannel.
+     *
+     * @return New LiftGestureSensorChannel as AbstractSensorChannel*
+     */
+    static AbstractSensorChannel *factoryMethod(const QString &id)
+    {
+        LiftGestureSensorChannel *sc = new LiftGestureSensorChannel(id);
+        new LiftGestureSensorChannelAdaptor(sc);
+
+        return sc;
+    }
+
+    /** Property for accessing the measured value.
+     *
+     * Note that sensor does not have a state and thus
+     * the last measured value is meaningness and is
+     * provided only for the sake of symmetry.
+     *
+     * @return Last measured value.
+     */
+    Unsigned liftGesture() const { return m_previousValue; }
+
+public Q_SLOTS:
+    bool start();
+    bool stop();
+
+signals:
+    /** Sent when a change in measured data is observed.
+     *
+     * @param value Measured value.
+     */
+    void liftGestureChanged(const Unsigned &value);
+
+protected:
+    LiftGestureSensorChannel(const QString &id);
+    virtual ~LiftGestureSensorChannel();
+
+private:
+    TimedUnsigned m_previousValue;
+    Bin *m_filterBin;
+    Bin *m_marshallingBin;
+    DeviceAdaptor *m_liftGestureAdaptor;
+    BufferReader<TimedUnsigned> *m_liftGestureReader;
+    RingBuffer<TimedUnsigned> *m_outputBuffer;
+
+    void emitData(const TimedUnsigned &value);
+};
+#endif // LIFTGESTURE_SENSOR_CHANNEL_H

--- a/sensors/liftgesturesensor/liftgesturesensor.pro
+++ b/sensors/liftgesturesensor/liftgesturesensor.pro
@@ -1,0 +1,18 @@
+CONFIG += link_pkgconfig
+
+TARGET = liftgesturesensor
+
+HEADERS += liftgesturesensor.h \
+           liftgesturesensor_a.h \
+           liftgestureplugin.h
+
+SOURCES += liftgesturesensor.cpp \
+           liftgesturesensor_a.cpp \
+           liftgestureplugin.cpp
+
+include( ../sensor-config.pri )
+
+contextprovider {
+    DEFINES += PROVIDE_CONTEXT_INFO
+    PKGCONFIG += contextprovider-1.0
+}

--- a/sensors/liftgesturesensor/liftgesturesensor_a.cpp
+++ b/sensors/liftgesturesensor/liftgesturesensor_a.cpp
@@ -1,0 +1,29 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "liftgesturesensor_a.h"
+
+LiftGestureSensorChannelAdaptor::LiftGestureSensorChannelAdaptor(QObject *parent)
+    : AbstractSensorChannelAdaptor(parent)
+{
+}
+
+Unsigned LiftGestureSensorChannelAdaptor::liftGesture() const
+{
+    return qvariant_cast<Unsigned>(parent()->property("liftgesture"));
+}

--- a/sensors/liftgesturesensor/liftgesturesensor_a.h
+++ b/sensors/liftgesturesensor/liftgesturesensor_a.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+**
+** Copyright (c) 2025 Jollyboys Ltd.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef LIFTGESTURE_SENSOR_H
+#define LIFTGESTURE_SENSOR_H
+
+#include <QtDBus/QtDBus>
+#include <QObject>
+
+#include "datatypes/unsigned.h"
+#include "abstractsensor_a.h"
+
+class LiftGestureSensorChannelAdaptor : public AbstractSensorChannelAdaptor
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(LiftGestureSensorChannelAdaptor)
+    Q_CLASSINFO("D-Bus Interface", "local.LiftGestureSensor")
+    Q_PROPERTY(Unsigned liftGesture READ liftGesture NOTIFY liftGestureChanged)
+
+public:
+    LiftGestureSensorChannelAdaptor(QObject *parent);
+
+public Q_SLOTS:
+    Unsigned liftGesture() const;
+
+Q_SIGNALS:
+    void liftGestureChanged(const Unsigned &value);
+};
+#endif // LIFTGESTURE_SENSOR_H

--- a/sensors/sensors.pro
+++ b/sensors/sensors.pro
@@ -17,6 +17,9 @@ SUBDIRS  = accelerometersensor \
            pressuresensor \
            wakeupsensor \
            temperaturesensor \
-           stepcountersensor
+           stepcountersensor \
+           chopchopsensor \
+           cameragesturesensor \
+           liftgesturesensor
 
 contextprovider:SUBDIRS += contextplugin


### PR DESCRIPTION
This PR adds motorola gestures. Since 2014 to at least 2023, every motorola (it's part of what they're known for) had gestures as sensors.

Aforementioned gestures are:
1.  Chop chop gesture - toggles flashlight
2. Camera gesture - you flip device twice to turn on camera
3. lift to wake gesture - self explanatory

I've copied implementation from wakeup sensor because they're basically the same, we do not care for the content, it in fact doesn't even change so theoretically there wouldn't even have to be any sent. I've noticed wakeup gesture has config for the ID which is useful because while chopchop/camera gestures did match with between my 2014 and 2023 motorolas, the lift gesture did not so that takes care of it. I've made daemon that connects to sensorfw, requests said plugins and then executes actions.

For every other device, these plugins would lay dormant, but if this PR got merged, it would mean I don't have to rebase my changes on every sailfishOS release (yes i'm lazy)

I've so far checked them on binder (2023 motorola edge 30 neo) and on hal (2014 moto x2) and they both work (it's literally copy paste + sed)

While I understand that it might not necessarily be merged, as it would be smarter to let's say, have one generic wake up sensor and use it for all 3 gestures, that would have to be developed not by me, because it's way outside of the scope of my sensorfw competency, I hope that this PR at least starts the talks on how can we resolve this.

Although if it was merged in this form in timely manner i wouldn't complain either :)